### PR TITLE
Add support for region eu-central-1

### DIFF
--- a/lib/env.php
+++ b/lib/env.php
@@ -32,11 +32,12 @@ function loadDotenv(): void {
             }
 
             // Validate environment variables
-            $dotenv->required("SPAPI_AWS_REGION")->allowedValues(["us-east-1", "us-west-2", "eu-west-1"]);
+            $dotenv->required("SPAPI_AWS_REGION")->allowedValues(["us-east-1", "us-west-2", "eu-west-1", "eu-central-1"]);
             $dotenv->required("SPAPI_ENDPOINT")->allowedValues([
                 "https://sellingpartnerapi-na.amazon.com",
                 "https://sellingpartnerapi-eu.amazon.com",
                 "https://sellingpartnerapi-fe.amazon.com",
+                "https://sellercentral-europe.amazon.com"
             ]);
 
             return;


### PR DESCRIPTION
Add support for region eu-central-1

``
Type: Dotenv\Exception\ValidationException
Code: 0
Message: One or more environment variables failed assertions: SPAPI_AWS_REGION is not one of [us-east-1, us-west-2, eu-west-1].
File: spapi-oauth\vendor\vlucas\phpdotenv\src\Validator.php
Line: 175
``