### PR TITLE
Revert: Add support for eu-central-1

### DIFF
--- a/lib/env.php
+++ b/lib/env.php
@@ -32,12 +32,11 @@ function loadDotenv(): void {
             }
 
             // Validate environment variables
-            $dotenv->required("SPAPI_AWS_REGION")->allowedValues(["us-east-1", "us-west-2", "eu-west-1", "eu-central-1"]);
+            $dotenv->required("SPAPI_AWS_REGION")->allowedValues(["us-east-1", "us-west-2", "eu-west-1"]);
             $dotenv->required("SPAPI_ENDPOINT")->allowedValues([
                 "https://sellingpartnerapi-na.amazon.com",
                 "https://sellingpartnerapi-eu.amazon.com",
                 "https://sellingpartnerapi-fe.amazon.com",
-                "https://sellercentral-europe.amazon.com"
             ]);
 
             return;


### PR DESCRIPTION
I think I made a mistake and need to revert it. The endpoint https://sellercentral.amazon.com is hardcoded  in spapi-oauth-template/app/routes.php and should be added to the .env enviroment.