### PR TITLE
Adding region in dynamic configuration, removed host and region from env required field. 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "jlevers/selling-partner-api",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "description": "PHP client for Amazon's Selling Partner API",
     "keywords": [
         "api",

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -62,7 +62,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'SellingPartnerAPI/2.0.6 (Language=PHP)';
+    protected $userAgent = 'SellingPartnerAPI/2.0.7 (Language=PHP)';
 
     /**
      * Debug switch (default set to false)
@@ -383,7 +383,7 @@ nnn     *
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . PHP_VERSION . PHP_EOL;
         $report .= '    The version of the OpenAPI document: 2020-11-01' . PHP_EOL;
-        $report .= '    SDK Package Version: 2.0.6' . PHP_EOL;
+        $report .= '    SDK Package Version: 2.0.7' . PHP_EOL;
         $report .= '    Temp Folder Path: ' . self::getDefaultConfiguration()->getTempFolderPath() . PHP_EOL;
 
         return $report;


### PR DESCRIPTION
Adding region in dynamic configuration, removed host and region from env required field. Now region and host are optional envs.
PR for the below issue
Ref issue: https://github.com/jlevers/selling-partner-api/issues/18