### PR TITLE
Change the check of the contentType

### DIFF
--- a/lib/Document.php
+++ b/lib/Document.php
@@ -37,7 +37,11 @@ class Document
             throw new \Exception($msg);
         }
 
-        if (!in_array($contentType, static::VALID_CONTENT_TYPES)) {
+        // Not defining a charset on the contentType throws an 400 - Invalid Input error from SP-API.
+        // That's why we must only check the first part of the contentType.
+        // Example: "text/tab-separated-values; charset=UTF-8"
+        $arrContentTypeParts = explode(";", $contentType);
+        if (!in_array(trim($arrContentTypeParts[0]), static::VALID_CONTENT_TYPES)) {
             throw new \InvalidArgumentException("valid contentType values are: " . implode(", ", static::VALID_CONTENT_TYPES));
         }
 


### PR DESCRIPTION
Not defining a charset on the contentType throws an 400 - Invalid Input error from SP-API.

Example: "text/tab-separated-values"
```
#message: "[400] {"errors":[{"code":"400","message":"Invalid input","details":"Invalid input"}]}"
#code: 400
#file: "./vendor/jlevers/selling-partner-api/lib/Api/FeedsApi.php"
#line: 996
```

That's why we must only check the first part of the contentType.
Example: "text/tab-separated-values; charset=UTF-8"