### PR TITLE
Fix authentication error on notifications API

### DIFF
--- a/lib/Authentication.php
+++ b/lib/Authentication.php
@@ -149,7 +149,7 @@ class Authentication
         }
         $accessToken = $credsForAccessToken->getSecurityToken();
 
-        $relevantCreds = $this->awsCredentials;
+        $relevantCreds = $scope === null ? $this->awsCredentials : $this->grantlessAwsCredentials;
         if ($this->roleArn !== null) {
             if ($this->roleCredentials === null || $this->roleCredentials->expiresSoon()) {
                 $client = new StsClient([
@@ -157,8 +157,8 @@ class Authentication
                     'region' => $this->region,
                     'version' => '2011-06-15',
                     'credentials' => [
-                      'key' => $relevantCreds ? $relevantCreds->getAccessKeyId() : $this->awsKey,
-                      'secret' => $relevantCreds ? $relevantCreds->getSecretKey() : $this->awsSecret,
+                      'key' => $this->awsKey,
+                      'secret' => $this->awsSecret,
                     ],
                 ]);
                 $assumeTime = time();

--- a/lib/Authentication.php
+++ b/lib/Authentication.php
@@ -157,8 +157,8 @@ class Authentication
                     'region' => $this->region,
                     'version' => '2011-06-15',
                     'credentials' => [
-                        'key' => $relevantCreds->getAccessKeyId(),
-                        'secret' => $relevantCreds->getSecretKey(),
+                      'key' => $relevantCreds ? $relevantCreds->getAccessKeyId() : $this->awsKey,
+                      'secret' => $relevantCreds ? $relevantCreds->getSecretKey() : $this->awsSecret,
                     ],
                 ]);
                 $assumeTime = time();

--- a/lib/Authentication.php
+++ b/lib/Authentication.php
@@ -157,8 +157,8 @@ class Authentication
                     'region' => $this->region,
                     'version' => '2011-06-15',
                     'credentials' => [
-                      'key' => $this->awsKey,
-                      'secret' => $this->awsSecret,
+                        'key' => $this->awsKey,
+                        'secret' => $this->awsSecret,
                     ],
                 ]);
                 $assumeTime = time();

--- a/lib/Authentication.php
+++ b/lib/Authentication.php
@@ -157,8 +157,8 @@ class Authentication
                     'region' => $this->region,
                     'version' => '2011-06-15',
                     'credentials' => [
-                        'key' => $this->awsKey,
-                        'secret' => $this->awsSecret,
+                        'key' => $relevantCreds->getAccessKeyId(),
+                        'secret' => $relevantCreds->getSecretKey(),
                     ],
                 ]);
                 $assumeTime = time();


### PR DESCRIPTION
This PR fixes an error that I've been facing when I was trying to use the Notifications API.

### Error:
```
Fatal error: Uncaught Error: Call to a member function getAccessKeyId() on null in /selling-partner-api/lib/Authentication.php:163
```

### Steps to reproduce:
1. Create a file named "index.php" to make requests using `Notifications API`:
```
<?php
require_once(__DIR__ . '/vendor/autoload.php');

$configurationOptions = new SellingPartnerApi\ConfigurationOptions(
  "amzn1.application-oa2-client.cb...",
  "1caced...",
  "Atzr|...",
  "AKIA...",
  "unTBt/...",
  "us-east-1",
  "https://sellingpartnerapi-na.amazon.com",
  null,
  null,
  null,
  "arn:aws:iam..." // arn
);
$config = new SellingPartnerApi\Configuration($configurationOptions);

$apiInstance = new SellingPartnerApi\Api\NotificationsApi($config);
$body = new \SellingPartnerApi\Model\Notifications\CreateDestinationRequest([
  'name' => 'myFirstQueue',
  'resource_specification' => [
    'sqs' => [
      'arn' => 'arn:aws:sqs:us-east-1:588738727431:myFirstQueue'
    ]
  ]
]); // \SellingPartnerApi\Model\Notifications\CreateDestinationRequest

try {
  $result = $apiInstance->createDestination($body);
  print_r($result);
} catch (Exception $e) {
  echo 'Exception when calling NotificationsApi->createDestination: ', $e->getMessage(), PHP_EOL;
}

```

2. Use the command `php -S localhost:8000` to listen the project, then go to your browser and access `http://localhost:8000`.