### PR TITLE
Make text/plain file downloadable

### DIFF
--- a/lib/ContentType.php
+++ b/lib/ContentType.php
@@ -14,6 +14,7 @@ class ContentType {
     public const TAB = 'text/tab-separated-values';
     public const XLSX = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
     public const XML = 'text/xml';
+    public const TXT = 'text/plain';
 
     public static function getContentTypes(): array
     {

--- a/lib/Document.php
+++ b/lib/Document.php
@@ -116,6 +116,8 @@ class Document
 
             $spreadsheet = IOFactory::load($this->tmpFilename);
             $this->data = $spreadsheet;
+        } else if ($this->contentType === ContentType::TXT) {
+            $this->data = $contents;
         }
 
         return $contents;

--- a/lib/Document.php
+++ b/lib/Document.php
@@ -13,7 +13,7 @@ use SellingPartnerApi\Model;
 class Document
 {
     public const ENCRYPTION_SCHEME = "AES-256-CBC";
-    public const VALID_CONTENT_TYPES = ["text/xml", "text/tab-separated-values", "text/csv"];
+    public const VALID_CONTENT_TYPES = ["text/xml", "text/tab-separated-values", "text/csv", "application/pdf"];
 
     private $iv;
     private $key;

--- a/lib/Document.php
+++ b/lib/Document.php
@@ -13,7 +13,7 @@ use SellingPartnerApi\Model;
 class Document
 {
     public const ENCRYPTION_SCHEME = "AES-256-CBC";
-    public const VALID_CONTENT_TYPES = ["text/xml", "text/tab-separated-values", "text/csv", "application/pdf"];
+    public const VALID_CONTENT_TYPES = ["text/xml", "text/tab-separated-values", "text/csv", "application/pdf", "text/plain"];
 
     private $iv;
     private $key;
@@ -95,6 +95,8 @@ class Document
             }
             $this->data = $data;
             fclose($bareStream);
+        } else if ($this->contentType === "application/pdf" || $this->contentType === "text/plain") {
+            $data = $contents;
         }
 
         return $contents;


### PR DESCRIPTION
When using the UPLOAD_VAT_INVOICE, the Amazon API gives a result_feed_document_id that is a plain text file, holding this kind of information :

```
Feed Processing Summary:
        Number of records processed             1
        Number of records successful            0

original-record-number  sku     error-code      error-type      error-message
1               12345   Error   Please provide metadata:shippingid or metadata:orderid,metadata:invoicenumber,metadata:totalamount,metadata:totalvatamount
```