### PR TITLE
Added EndPoints catalogItemsV0.md

### DIFF
--- a/lib/Api/CatalogApi.php
+++ b/lib/Api/CatalogApi.php
@@ -106,9 +106,883 @@ class CatalogApi
     /**
      * @return Configuration
      */
+
     public function getConfig()
     {
         return $this->config;
+    }
+
+
+    /**
+     * Create request for operation 'listCatalogCategories'
+     *
+     * @param  string[] $marketplace_ids A comma-delimited list of Amazon marketplace identifiers. Data sets in the response contain data only for the specified marketplaces. (required)
+     * @param  array $kwargs The Amazon Standard Identification Number (ASIN) of the item. (optional) or sku item (SellerSKU) in the given marketplace. (optional)
+     *  $result = $apiInstance->listCatalogCategories($marketplace_id, array('SellerSKU'=> $seller_sku));
+     *  $result = $apiInstance->listCatalogCategories($marketplace_id, array('ASIN'=> $asin));
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+    public function listCatalogCategories(string $marketplace_id, $kwargs = null)
+    {
+        list($response) = $this->listCatalogCategoriesWithHttpInfo($marketplace_id, $kwargs);
+        return $response;
+    }
+
+    public function listCatalogCategoriesWithHttpInfo($marketplace_id, $kwargs = null)
+    {
+        $request = $this->listCatalogCategoriesRequest($marketplace_id, $kwargs);
+
+        $signedRequest = $this->config->signRequest(
+            $request
+        );
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($signedRequest, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getResponse()->getBody()->getContents()}",
+                    $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody()->getContents() : null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        $signedRequest->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    $response->getBody()->getContents()
+                );
+            }
+
+            $responseBody = $response->getBody();
+            $responseHeaders = $response->getHeaders();
+
+            switch($statusCode) {
+                case 200:
+                    if ('\SellingPartnerApi\Model\Catalog\ListCatalogItemsResponse' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ListCatalogCategoriesResponse', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 400:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 403:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 404:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 413:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 415:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 429:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 500:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 503:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+
+        } catch (ApiException $e) {
+            throw $e;
+        }
+    }
+
+    public function listCatalogCategoriesRequest($marketplace_id, $kwargs = null)
+    {
+        // verify the required parameter 'marketplace_id' is set
+        if ($marketplace_id === null) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $marketplace_id when calling listCatalogItem'
+            );
+        }
+        if ($kwargs === null) {
+            throw new \InvalidArgumentException(
+                'MarketplaceId is always required. At least one of ASIN, SellerSKU'
+            );
+        }
+
+        $resourcePath = '/catalog/v0/categories';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+        if ($marketplace_id !== null) {
+            $queryParams['MarketplaceId'] = $marketplace_id;
+        }
+
+        $queryParams = array_merge($queryParams, $kwargs);
+
+        if ($multipart) {
+            $headers = $this->headerSelector->selectHeadersForMultipart(
+                ['application/json']
+            );
+        } else {
+            $headers = $this->headerSelector->selectHeaders(
+                ['application/json'],
+                []
+            );
+        }
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($formParams);
+
+            } else {
+                // for HTTP post (form)
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+            }
+        }
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
+
+        return new Request(
+            'GET',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Create request for operation 'listCatalogCategories'
+     *
+     * @param  string[] $marketplace_id (MarketplaceId) A marketplace identifier. Specifies the marketplace for which items are returned. (required)
+     * @param  array $kwargs
+     * Returns a list of items and their attributes, based on a search query or item identifiers that you specify.
+     * When based on a search query, provide the Query parameter and optionally, the QueryContextId parameter.
+     * When based on item identifiers, provide a single appropriate parameter based on the identifier type, and specify the associated item value.
+     * MarketplaceId is always required. At least one of Query (QueryContextId), SellerSKU, UPC, EAN, ISBN, JAN is also required.
+     * $result = $apiInstance->listCatalogItem($marketplace_id, array('Query'=> $query));
+     * $result = $apiInstance->listCatalogItem($marketplace_id, array('Query'=> $query, 'QueryContextId'=> $query_context_id));
+     * $result = $apiInstance->listCatalogItem($marketplace_id, array('SellerSKU'=> $seller_sku));
+     * $result = $apiInstance->listCatalogItem($marketplace_id, array('UPC'=> $upc));
+     * $result = $apiInstance->listCatalogItem($marketplace_id, array('EAN'=> $ean));
+     * $result = $apiInstance->listCatalogItem($marketplace_id, array('JAN'=> $jan));
+     * $result = $apiInstance->listCatalogItem($marketplace_id, array('ISBN'=> $isbn));
+     * @throws \InvalidArgumentException
+     * @return \GuzzleHttp\Psr7\Request
+     */
+
+    public function listCatalogItem(string $marketplace_id, $kwargs = null)
+    {
+        list($response) = $this->listCatalogItemWithHttpInfo($marketplace_id, $kwargs);
+        return $response;
+    }
+
+    public function listCatalogItemWithHttpInfo($marketplace_id, $kwargs = null)
+    {
+        $request = $this->listCatalogItemRequest($marketplace_id, $kwargs);
+
+        $signedRequest = $this->config->signRequest(
+            $request
+        );
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($signedRequest, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getResponse()->getBody()->getContents()}",
+                    $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody()->getContents() : null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        $signedRequest->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    $response->getBody()->getContents()
+                );
+            }
+
+            $responseBody = $response->getBody();
+            $responseHeaders = $response->getHeaders();
+
+            switch($statusCode) {
+                case 200:
+                    if ('\SellingPartnerApi\Model\Catalog\ListCatalogItemsResponse' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ListCatalogItemsResponse', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 400:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 403:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 404:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 413:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 415:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 429:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 500:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 503:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+        } catch (ApiException $e) {
+            throw $e;
+        }
+    }
+
+    public function listCatalogItemRequest($marketplace_id, $kwargs = null)
+    {
+        // verify the required parameter 'marketplace_ids' is set
+        if ($marketplace_id === null) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $marketplace_id when calling listCatalogItem'
+            );
+        }
+
+        if ($kwargs === null) {
+            throw new \InvalidArgumentException(
+                'MarketplaceId is always required. At least one of Query, SellerSKU, UPC, EAN, ISBN, JAN is also required'
+            );
+        }
+
+        $resourcePath = '/catalog/v0/items';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+
+        if ($marketplace_id !== null) {
+            $queryParams['MarketplaceId'] = $marketplace_id;
+        }
+
+        $queryParams = array_merge($queryParams, $kwargs);
+
+        if ($multipart) {
+            $headers = $this->headerSelector->selectHeadersForMultipart(
+                ['application/json']
+            );
+        } else {
+            $headers = $this->headerSelector->selectHeaders(
+                ['application/json'],
+                []
+            );
+        }
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($formParams);
+
+            } else {
+                // for HTTP post (form)
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+            }
+        }
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
+
+        return new Request(
+            'GET',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
+    }
+
+    /**
+     * Operation getCatalogItem (catalogItemsV0.md)
+     *
+     * @param  string $asin The Amazon Standard Identification Number (ASIN) of the item. (required)
+     * @param  string $marketplace_id A marketplace identifier. Specifies the marketplace for the item (required)
+     * $result = $apiInstance->getCatalogItemV0($asin, $marketplace_id);
+     * @throws \SellingPartnerApi\ApiException on non-2xx response
+     * @throws \InvalidArgumentException
+     * @return \SellingPartnerApi\Model\Catalog\Item
+     */
+
+    public function getCatalogItemV0($asin, $marketplace_id)
+    {
+        list($response) = $this->getCatalogItemV0WithHttpInfo($asin, $marketplace_id);
+        return $response;
+    }
+
+    public function getCatalogItemV0WithHttpInfo($asin, $marketplace_id)
+    {
+        $request = $this->getCatalogItemV0Request($asin, $marketplace_id);
+        $signedRequest = $this->config->signRequest(
+            $request
+        );
+
+        try {
+            $options = $this->createHttpClientOption();
+            try {
+                $response = $this->client->send($signedRequest, $options);
+            } catch (RequestException $e) {
+                throw new ApiException(
+                    "[{$e->getCode()}] {$e->getResponse()->getBody()->getContents()}",
+                    $e->getCode(),
+                    $e->getResponse() ? $e->getResponse()->getHeaders() : null,
+                    $e->getResponse() ? (string) $e->getResponse()->getBody()->getContents() : null
+                );
+            }
+
+            $statusCode = $response->getStatusCode();
+
+            if ($statusCode < 200 || $statusCode > 299) {
+                throw new ApiException(
+                    sprintf(
+                        '[%d] Error connecting to the API (%s)',
+                        $statusCode,
+                        $signedRequest->getUri()
+                    ),
+                    $statusCode,
+                    $response->getHeaders(),
+                    $response->getBody()->getContents()
+                );
+            }
+
+            $responseBody = $response->getBody();
+            switch($statusCode) {
+                case 200:
+                    if ('\SellingPartnerApi\Model\Catalog\Item' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\GetCatalogItemResponse', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 400:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 403:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 404:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 413:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 415:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 429:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 500:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+                case 503:
+                    if ('\SellingPartnerApi\Model\Catalog\ErrorList' === '\SplFileObject') {
+                        $content = $responseBody; //stream goes to serializer
+                    } else {
+                        $content = (string) $responseBody;
+                    }
+
+                    return [
+                        ObjectSerializer::deserialize($content, '\SellingPartnerApi\Model\Catalog\ErrorList', []),
+                        $response->getStatusCode(),
+                        $response->getHeaders()
+                    ];
+            }
+
+            $returnType = '\SellingPartnerApi\Model\Catalog\Item';
+            $responseBody = $response->getBody();
+            if ($returnType === '\SplFileObject') {
+                $content = $responseBody; //stream goes to serializer
+            } else {
+                $content = (string) $responseBody;
+            }
+
+            return [
+                ObjectSerializer::deserialize($content, $returnType, []),
+                $response->getStatusCode(),
+                $response->getHeaders()
+            ];
+
+        } catch (ApiException $e) {
+            switch ($e->getCode()) {
+                case 200:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SellingPartnerApi\Model\Catalog\Item',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 400:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SellingPartnerApi\Model\Catalog\ErrorList',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 403:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SellingPartnerApi\Model\Catalog\ErrorList',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 404:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SellingPartnerApi\Model\Catalog\ErrorList',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 413:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SellingPartnerApi\Model\Catalog\ErrorList',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 415:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SellingPartnerApi\Model\Catalog\ErrorList',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 429:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SellingPartnerApi\Model\Catalog\ErrorList',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 500:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SellingPartnerApi\Model\Catalog\ErrorList',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+                case 503:
+                    $data = ObjectSerializer::deserialize(
+                        $e->getResponseBody(),
+                        '\SellingPartnerApi\Model\Catalog\ErrorList',
+                        $e->getResponseHeaders()
+                    );
+                    $e->setResponseObject($data);
+                    break;
+            }
+            throw $e;
+        }
+    }
+
+    public function getCatalogItemV0Request($asin, $marketplace_id)
+    {
+        // verify the required parameter 'asin' is set
+        if ($asin === null || (is_array($asin) && count($asin) === 0)) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $asin when calling getCatalogItem'
+            );
+        }
+        // verify the required parameter 'marketplace_ids' is set
+        if ($marketplace_id === null) {
+            throw new \InvalidArgumentException(
+                'Missing the required parameter $marketplace_id when calling getCatalogItem'
+            );
+        }
+
+        $resourcePath = '/catalog/v0/items/{asin}';
+        $formParams = [];
+        $queryParams = [];
+        $headerParams = [];
+        $httpBody = '';
+        $multipart = false;
+
+        // query params
+        if ($marketplace_id !== null) {
+            $queryParams['MarketplaceId'] = $marketplace_id;
+        }
+        // path params
+        if ($asin !== null) {
+            $resourcePath = str_replace(
+                '{' . 'asin' . '}',
+                ObjectSerializer::toPathValue($asin),
+                $resourcePath
+            );
+        }
+
+
+        if ($multipart) {
+            $headers = $this->headerSelector->selectHeadersForMultipart(
+                ['application/json']
+            );
+        } else {
+            $headers = $this->headerSelector->selectHeaders(
+                ['application/json'],
+                []
+            );
+        }
+
+        // for model (json/xml)
+        if (count($formParams) > 0) {
+            if ($multipart) {
+                $multipartContents = [];
+                foreach ($formParams as $formParamName => $formParamValue) {
+                    $formParamValueItems = is_array($formParamValue) ? $formParamValue : [$formParamValue];
+                    foreach ($formParamValueItems as $formParamValueItem) {
+                        $multipartContents[] = [
+                            'name' => $formParamName,
+                            'contents' => $formParamValueItem
+                        ];
+                    }
+                }
+                // for HTTP post (form)
+                $httpBody = new MultipartStream($multipartContents);
+
+            } elseif ($headers['Content-Type'] === 'application/json') {
+                $httpBody = \GuzzleHttp\json_encode($formParams);
+
+            } else {
+                // for HTTP post (form)
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+            }
+        }
+
+
+        $defaultHeaders = [];
+        if ($this->config->getUserAgent()) {
+            $defaultHeaders['User-Agent'] = $this->config->getUserAgent();
+        }
+
+        $headers = array_merge(
+            $defaultHeaders,
+            $headerParams,
+            $headers
+        );
+
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
+        return new Request(
+            'GET',
+            $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
+            $headers,
+            $httpBody
+        );
     }
 
     /**
@@ -128,6 +1002,7 @@ class CatalogApi
         list($response) = $this->getCatalogItemWithHttpInfo($asin, $marketplace_ids, $included_data, $locale);
         return $response;
     }
+
 
     /**
      * Operation getCatalogItemWithHttpInfo
@@ -150,6 +1025,7 @@ class CatalogApi
 
         try {
             $options = $this->createHttpClientOption();
+            var_dump($options);
             try {
                 $response = $this->client->send($signedRequest, $options);
             } catch (RequestException $e) {
@@ -557,7 +1433,7 @@ class CatalogApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
             }
         }
 
@@ -573,7 +1449,7 @@ class CatalogApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),
@@ -1095,7 +1971,7 @@ class CatalogApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\Query::build($formParams);
+                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
             }
         }
 
@@ -1111,7 +1987,7 @@ class CatalogApi
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\Query::build($queryParams);
+        $query = \GuzzleHttp\Psr7\build_query($queryParams);
         return new Request(
             'GET',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),


### PR DESCRIPTION
Added 3 endpoints missing of catalogItemsV0.md:

GET /catalog/v0/items
Operation: listCatalogItems

GET /catalog/v0/items/{asin}
Operation: getCatalogItem
**Due naming used of catalogItems_2020-12-01.md of the same operation against other end point the new name to call is getCatalogItemV0

GET /catalog/v0/categories
Operation: listCatalogCategories

-----------------------------------------

I Suggest Split in Two Sub-Apis:

1. CatalogApi
listCatalogItems (GET /catalog/v0/items)
`getCatalogItem (GET /catalog/v0/items/{asin})`
listCatalogCategories (GET /catalog/v0/categories)

2. CatalogItemApi for 
searchCatalogItems (GET /catalog/2020-12-01/items)
`getCatalogItem (GET /catalog/2020-12-01/items/{asin})`


In that way both methods getCatalogItem  will not interfere and could keep the naming convention



[https://github.com/amzn/selling-partner-api-docs/blob/main/references/catalog-items-api/catalogItemsV0.md#getcatalogitem](https://github.com/amzn/selling-partner-api-docs/blob/main/references/catalog-items-api/catalogItemsV0.md#getcatalogitem)