### PR TITLE
Allow composer installation with Guzzle 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^7.2",
+        "guzzlehttp/guzzle": "^6.0|^7.0",
         "phpoffice/phpspreadsheet": "^1.18",
         "aws/aws-sdk-php": "^3.185"
     },


### PR DESCRIPTION
After a quick look to [BC breaking changes](https://github.com/guzzle/guzzle/blob/7.0.0/UPGRADING.md#60-to-70) introduced in Guzzle 7, I don't see anything that would prevent this library from working with Guzzle 6. There's many applications including popular frameworks that still require Guzzle 6 and that prevents this library from being installed and used.

I will be testing if things work over the next few weeks, is there any known compatibility issue?