### PR TITLE
Moving setRequestTime after fetching newest creds from Amazon

### DIFF
--- a/lib/Authentication.php
+++ b/lib/Authentication.php
@@ -131,7 +131,6 @@ class Authentication
      */
     public function signRequest(Psr7\Request $request, ?string $scope = null, ?string $restrictedPath = null, ?string $operation = null): Psr7\Request
     {
-        $this->setRequestTime();
         // Check if the relevant AWS creds haven't been fetched or are expiring soon
         $relevantCreds = null;
         $params = [];
@@ -180,6 +179,8 @@ class Authentication
             $relevantCreds = $this->getRoleCredentials();
         }
 
+        $this->setRequestTime();
+        
         $canonicalRequest = $this->createCanonicalRequest($request);
         $signingString = $this->createSigningString($canonicalRequest);
         $signature = $this->createSignature($signingString, $relevantCreds->getSecretKey());


### PR DESCRIPTION
We faced that in some cases amazon may respond with such error:
```
[403] {
  "errors": [
    {
      "message": "Signature expired: 20211013T140559Z is now earlier than 20211013T140604Z (20211013T141104Z - 5 min.)",
     "code": "InvalidSignature"
    }
  ]
}
```

we suppose it can happen due to some delay by fetching new token/RDT token & etc.
so we suggest just move  `$this->setRequestTime();` method call after all fetching operations.

p.s.
example of raw request & response with mentioned issue
### Request
```
GET /orders/v0/orders/***/orderItems HTTP/1.1                                                                                                                                           
User-Agent: Valigara (Language=PHP)                                                                                                                                                                               
Accept: application/json                                                                                                                                                                                          
Content-Type: application/json                                                                                                                                                                                    
Host: sellingpartnerapi-na.amazon.com                                                                                                                                                                             
Authorization: ***                                                                                                                                                                                    
x-amz-security-token: ***                                                                                                                                                                       
x-amz-access-token: ***                                                                                                                                                                      
x-amz-date: 20211013T140559Z                                                                                                                                                                                      
                            
```
### Response
```
HTTP/1.1 403 Forbidden                                                                                                                                                                                         
Date: Wed, 13 Oct 2021 14:11:04 GMT                                                                                                                                                                               
Content-Type: application/json                                                                                                                                                                                    
Content-Length: 186                                                                                                                                                                                               
Connection: keep-alive                                                                                                                                                                                            
x-amzn-RequestId: 0e616f94-91ff-4362-b57a-f9045d4fbf5a                                                                                                                                                            
x-amzn-ErrorType: InvalidSignatureException                                                                                                                                                                       
x-amz-apigw-id: HJlW2FKMoAMFUfw=                                                                                                                                                                                  
                                                                                                                                                                                                                  
{"errors":[{"message":"Signature expired: 20211013T140559Z is now earlier than 20211013T140604Z (20211013T141104Z - 5 min.)","code":"InvalidSignature"}]}
```
