### PR TITLE
FIX: searchContentDocuments - invalid length for $name 

### DIFF
--- a/lib/Model/AplusContent/ContentMetadata.php
+++ b/lib/Model/AplusContent/ContentMetadata.php
@@ -45,7 +45,7 @@ use \SellingPartnerApi\Model\ModelInterface;
 class ContentMetadata implements ModelInterface, ArrayAccess, \JsonSerializable
 {
     public const DISCRIMINATOR = null;
-    
+
     /**
       * The original name of the model.
       *

--- a/lib/Model/AplusContent/ContentMetadata.php
+++ b/lib/Model/AplusContent/ContentMetadata.php
@@ -45,6 +45,8 @@ use \SellingPartnerApi\Model\ModelInterface;
 class ContentMetadata implements ModelInterface, ArrayAccess, \JsonSerializable
 {
     public const DISCRIMINATOR = null;
+    
+    private const NAME_MAX_LENGTH = 200;
 
     /**
       * The original name of the model.
@@ -222,8 +224,8 @@ class ContentMetadata implements ModelInterface, ArrayAccess, \JsonSerializable
         if ($this->container['name'] === null) {
             $invalidProperties[] = "'name' can't be null";
         }
-        if ((mb_strlen($this->container['name']) > 100)) {
-            $invalidProperties[] = "invalid value for 'name', the character length must be smaller than or equal to 100.";
+        if ((mb_strlen($this->container['name']) > self::NAME_MAX_LENGTH)) {
+            $invalidProperties[] = spritnf("invalid value for 'name', the character length must be smaller than or equal to %d.", self::NAME_MAX_LENGTH);
         }
 
         if ((mb_strlen($this->container['name']) < 1)) {
@@ -304,8 +306,8 @@ class ContentMetadata implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
-        if ((mb_strlen($name) > 100)) {
-            throw new \InvalidArgumentException('invalid length for $name when calling ContentMetadata., must be smaller than or equal to 100.');
+        if ((mb_strlen($name) > self::NAME_MAX_LENGTH)) {
+            throw new \InvalidArgumentException(sprintf('invalid length for $name when calling ContentMetadata., must be smaller than or equal to %d.', self::NAME_MAX_LENGTH));
         }
         if ((mb_strlen($name) < 1)) {
             throw new \InvalidArgumentException('invalid length for $name when calling ContentMetadata., must be bigger than or equal to 1.');

--- a/lib/Model/AplusContent/ContentMetadata.php
+++ b/lib/Model/AplusContent/ContentMetadata.php
@@ -46,8 +46,6 @@ class ContentMetadata implements ModelInterface, ArrayAccess, \JsonSerializable
 {
     public const DISCRIMINATOR = null;
     
-    private const NAME_MAX_LENGTH = 200;
-
     /**
       * The original name of the model.
       *
@@ -224,8 +222,8 @@ class ContentMetadata implements ModelInterface, ArrayAccess, \JsonSerializable
         if ($this->container['name'] === null) {
             $invalidProperties[] = "'name' can't be null";
         }
-        if ((mb_strlen($this->container['name']) > self::NAME_MAX_LENGTH)) {
-            $invalidProperties[] = sprintf("invalid value for 'name', the character length must be smaller than or equal to %d.", self::NAME_MAX_LENGTH);
+        if ((mb_strlen($this->container['name']) > 200)) {
+            $invalidProperties[] = "invalid value for 'name', the character length must be smaller than or equal to 200.";
         }
 
         if ((mb_strlen($this->container['name']) < 1)) {
@@ -306,8 +304,8 @@ class ContentMetadata implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setName($name)
     {
-        if ((mb_strlen($name) > self::NAME_MAX_LENGTH)) {
-            throw new \InvalidArgumentException(sprintf('invalid length for $name when calling ContentMetadata., must be smaller than or equal to %d.', self::NAME_MAX_LENGTH));
+        if ((mb_strlen($name) > 200)) {
+            throw new \InvalidArgumentException('invalid length for $name when calling ContentMetadata., must be smaller than or equal to 200.');
         }
         if ((mb_strlen($name) < 1)) {
             throw new \InvalidArgumentException('invalid length for $name when calling ContentMetadata., must be bigger than or equal to 1.');

--- a/lib/Model/AplusContent/ContentMetadata.php
+++ b/lib/Model/AplusContent/ContentMetadata.php
@@ -225,7 +225,7 @@ class ContentMetadata implements ModelInterface, ArrayAccess, \JsonSerializable
             $invalidProperties[] = "'name' can't be null";
         }
         if ((mb_strlen($this->container['name']) > self::NAME_MAX_LENGTH)) {
-            $invalidProperties[] = spritnf("invalid value for 'name', the character length must be smaller than or equal to %d.", self::NAME_MAX_LENGTH);
+            $invalidProperties[] = sprintf("invalid value for 'name', the character length must be smaller than or equal to %d.", self::NAME_MAX_LENGTH);
         }
 
         if ((mb_strlen($this->container['name']) < 1)) {


### PR DESCRIPTION
We faced that `searchContentDocuments` may return `ContentMetadata` records with `name` greater than 100 regardless api docs
e.g.
`MJ0504P1MOP/PSI - Lavari - White Mother of Pearl Prima Donna Pendant Necklace with Rose Gold Plating and Cubic Zirconia - Pink Sterling Silver` -> 142
#### Request
```
GET /aplus/2020-11-01/contentDocuments?marketplaceId=ATVPDKIKX0DER HTTP/1.1
User-Agent: jlevers/selling-partner-api/4.0.3 (Language=PHP)
Accept: application/json
Content-Type: application/json
Host: sellingpartnerapi-na.amazon.com
Authorization: AWS4-HMAC-SHA256 ***
x-amz-security-token: ***
x-amz-access-token: ***
x-amz-date: 20211020T085444Z

```
#### Response
```
HTTP/1.1 200 OK
Date: Wed, 20 Oct 2021 08:54:46 GMT
Content-Type: application/json
Content-Length: 132234
Connection: keep-alive
x-amzn-RequestId: 54b3f3f4-c88d-4741-aa3d-c4c960a96fb1
x-amzn-RateLimit-Limit: 10.0
x-amz-apigw-id: Hf7lYGhpoAMF6qg=
X-Amzn-Trace-Id: Root=1-616fd955-0110b0b26522f16566bbed5b

{
    "warnings": [
    ],
    "nextPageToken": null,
    "contentMetadataRecords": [
        {
            "contentReferenceKey": "be3fb2d5-***",
            "contentMetadata": {
                "name": "MJ0504P1MOP/PSI - Lavari - White Mother of Pearl Prima Donna Pendant Necklace with Rose Gold Plating and Cubic Zirconia - Pink Sterling Silver",
                "marketplaceId": "ATVPDKIKX0DER",
                "status": "APPROVED",
                "badgeSet": [
                    "STANDARD",
                    "GENERATED"
                ],
                "updateTime": "2020-10-06T11:32:47.341Z"
            }
        }
    ]
}
```

in this pull request we suggest to raise current limitation from `100` to `200`
