### PR TITLE
Option to bypass TokensApi object for RDT token api on automatic RDT generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The array passed to the `Configuration` constructor accepts the following keys:
 * `accessTokenExpiration (int)`: A Unix timestamp corresponding to the time when the `accessToken` expires. If `accessToken` is given, `accessTokenExpiration` is required (and vice versa).
 * `onUpdateCredentials (callable|Closure)`: A callback function to call when a new access token is generated. The function should accept a single argument of type [`SellingPartnerApi\Credentials`](https://github.com/jlevers/selling-partner-api/blob/main/lib/Credentials.php).
 * `roleArn (string)`: If you set up your SP API application with an AWS IAM role ARN instead of a user ARN, pass that ARN here.
+* `rdtTokensApiClient (GuzzleHttp\ClientInterface)`: Optional `GuzzleHttp\ClientInterface` object that will be used to fetch Restricted Data Token (RDT) upon automatic generation when you call a [restricted operation]((https://github.com/amzn/selling-partner-api-docs/blob/main/guides/en-US/use-case-guides/tokens-api-use-case-guide/tokens-API-use-case-guide-2021-03-01.md))
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The array passed to the `Configuration` constructor accepts the following keys:
 * `accessTokenExpiration (int)`: A Unix timestamp corresponding to the time when the `accessToken` expires. If `accessToken` is given, `accessTokenExpiration` is required (and vice versa).
 * `onUpdateCredentials (callable|Closure)`: A callback function to call when a new access token is generated. The function should accept a single argument of type [`SellingPartnerApi\Credentials`](https://github.com/jlevers/selling-partner-api/blob/main/lib/Credentials.php).
 * `roleArn (string)`: If you set up your SP API application with an AWS IAM role ARN instead of a user ARN, pass that ARN here.
-* `rdtTokensApiClient (GuzzleHttp\ClientInterface)`: Optional `GuzzleHttp\ClientInterface` object that will be used to fetch Restricted Data Token (RDT) upon automatic generation when you call a [restricted operation]((https://github.com/amzn/selling-partner-api-docs/blob/main/guides/en-US/use-case-guides/tokens-api-use-case-guide/tokens-API-use-case-guide-2021-03-01.md))
+* `tokensApi (SellingPartnerApi\Api\TokensApi)`: Optional `SellingPartnerApi\Api\TokensApi` object that will be used to fetch Restricted Data Token (RDT) upon automatic generation when you call a [restricted operation]((https://github.com/amzn/selling-partner-api-docs/blob/main/guides/en-US/use-case-guides/tokens-api-use-case-guide/tokens-API-use-case-guide-2021-03-01.md))
 
 ### Example
 

--- a/lib/Authentication.php
+++ b/lib/Authentication.php
@@ -45,9 +45,9 @@ class Authentication
     
     /**
      * 
-     * @var \GuzzleHttp\ClientInterface
+     * @var \SellingPartnerApi\Api\TokensApi
      */
-    private $rdtTokensApiClient = null;
+    private $tokensApi = null;
 
     /**
      * Authentication constructor.
@@ -77,7 +77,7 @@ class Authentication
             $this->populateCredentials($this->awsAccessKeyId, $this->awsSecretAccessKey, $accessToken, $accessTokenExpiration);
         }
         
-        $this->rdtTokensApiClient = $configurationOptions['rdtTokensApiClient'] ?? null;
+        $this->tokensApi = $configurationOptions['tokensApi'] ?? null;
     }
 
     /**
@@ -309,19 +309,22 @@ class Authentication
         // Create a new RDT if no matching one exists or if the matching one is expired
         if ($this->needNewCredentials($existingCreds)) {
             $standardCredentials = $this->getAwsCredentials();
-            $config = new Configuration([
-                "lwaClientId" => $this->lwaClientId,
-                "lwaClientSecret" => $this->lwaClientSecret,
-                "lwaRefreshToken" => $this->lwaRefreshToken,
-                "lwaAuthUrl" => $this->lwaAuthUrl,
-                "awsAccessKeyId" => $this->awsAccessKeyId,
-                "awsSecretAccessKey" => $this->awsSecretAccessKey,
-                "accessToken" => $standardCredentials->getSecurityToken(),
-                "accessTokenExpiration" => $standardCredentials->getExpiration(),
-                "roleArn" => $this->roleArn,
-                "endpoint" => $this->endpoint,
-            ]);
-            $tokensApi = new Api\TokensApi($config, $this->rdtTokensApiClient);
+            $tokensApi = $this->tokensApi;
+            if (is_null($tokensApi)) {
+                $config = new Configuration([
+                    "lwaClientId" => $this->lwaClientId,
+                    "lwaClientSecret" => $this->lwaClientSecret,
+                    "lwaRefreshToken" => $this->lwaRefreshToken,
+                    "lwaAuthUrl" => $this->lwaAuthUrl,
+                    "awsAccessKeyId" => $this->awsAccessKeyId,
+                    "awsSecretAccessKey" => $this->awsSecretAccessKey,
+                    "accessToken" => $standardCredentials->getSecurityToken(),
+                    "accessTokenExpiration" => $standardCredentials->getExpiration(),
+                    "roleArn" => $this->roleArn,
+                    "endpoint" => $this->endpoint,
+                ]);
+                $tokensApi = new Api\TokensApi($config);
+            }
 
             $restrictedResource = new Model\Tokens\RestrictedResource([
                 "method" => $method,

--- a/lib/Authentication.php
+++ b/lib/Authentication.php
@@ -42,6 +42,12 @@ class Authentication
      * @var string
      */
     private $awsSecretAccessKey;
+    
+    /**
+     * 
+     * @var \GuzzleHttp\ClientInterface
+     */
+    private $rdtTokensApiClient = null;
 
     /**
      * Authentication constructor.
@@ -70,6 +76,8 @@ class Authentication
         if ($accessToken !== null && $accessTokenExpiration !== null) {
             $this->populateCredentials($this->awsAccessKeyId, $this->awsSecretAccessKey, $accessToken, $accessTokenExpiration);
         }
+        
+        $this->rdtTokensApiClient = $configurationOptions['rdtTokensApiClient'] ?? null;
     }
 
     /**
@@ -313,7 +321,7 @@ class Authentication
                 "roleArn" => $this->roleArn,
                 "endpoint" => $this->endpoint,
             ]);
-            $tokensApi = new Api\TokensApi($config);
+            $tokensApi = new Api\TokensApi($config, $this->rdtTokensApiClient);
 
             $restrictedResource = new Model\Tokens\RestrictedResource([
                 "method" => $method,


### PR DESCRIPTION
We faced issue with exceeding requests quota while creating RDT 
```
Client=504
[429] {
  "errors": [
    {
      "message": "You exceeded your quota for the requested resource.",
     "code": "QuotaExceeded"
    }
  ]
}
#0 /www/jewelry/include/composer/vendor/jlevers/selling-partner-api/lib/Api/TokensApi.php(125): SellingPartnerApi\Api\TokensApi->createRestrictedDataTokenWithHttpInfo(Object(SellingPartnerApi\Model\Tokens\CreateRestrictedDataTokenRequest))
#1 /www/jewelry/include/composer/vendor/jlevers/selling-partner-api/lib/Authentication.php(326): SellingPartnerApi\Api\TokensApi->createRestrictedDataToken(Object(SellingPartnerApi\Model\Tokens\CreateRestrictedDataTokenRequest))
```

so we suggest merge this pull request logic to allow bypass client object into `TokensApi` object,
it will allow to use bypassed `Client` object with injected middleware that will handle quota issues 
(e.g. will implement some server side leaky bucket algo.)

p.s.
also bypassing `Client` object also maybe handy to achieve requests logging in such case or proxy etc.

p.s.s.
i am wondering about similar logic for  `SellingPartnerApi\Authentication` class il be glad if you share your opinion about it