### PR TITLE
Download report with Guzzle and better encoding detection

### DIFF
--- a/lib/Document.php
+++ b/lib/Document.php
@@ -90,21 +90,19 @@ class Document
      * @return string The raw (unencrypted) document contents.
      */
     public function download(?bool $postProcess = true, ?string $encoding = null): string {
-		try {
-            $response = $this->client->request(
-                'GET', $this->url, ['stream' => true]
-            );
-		}
-		catch (\GuzzleHttp\Exception\ClientException $e) {
-		    $response = $e->getResponse();
-			if ($response->getStatusCode() == 404) {
+        try {
+            $response = $this->client->request('GET', $this->url, ['stream' => true]);
+        }
+        catch (\GuzzleHttp\Exception\ClientException $e) {
+            $response = $e->getResponse();
+            if ($response->getStatusCode() == 404) {
                 throw new RuntimeException("Document Report not Found ({$response->getStatusCode()}): {$response->getBody()}");
             }
             else {
                 throw $e;
             }
-		}
-			
+        }
+        
         $rawContents = $response->getBody()->getContents();
 
         $contents = null;
@@ -134,16 +132,16 @@ class Document
             }
             else
             {
-                $encodings = array('UTF-8');
+                $encodings = ['UTF-8'];
                 if ($response->hasHeader('content-type')) {
                     $httpContentType = $response->getHeader('content-type');
                     $parsedHeader = \GuzzleHttp\Psr7\Header::parse($httpContentType);
                     if (isset($parsedHeader[0]['charset'])) {
                         array_unshift($encodings, $parsedHeader[0]['charset']);
                     }
-				}
-				$encoding = mb_detect_encoding($contents, $encodings, true);
-			}
+                }
+                $encoding = mb_detect_encoding($contents, $encodings, true);
+            }
             $contents = mb_convert_encoding($contents, "UTF-8", $encoding ?? mb_internal_encoding());
         }
 

--- a/lib/Document.php
+++ b/lib/Document.php
@@ -90,7 +90,11 @@ class Document
      * @return string The raw (unencrypted) document contents.
      */
     public function download(?bool $postProcess = true, ?string $encoding = null): string {
-        $rawContents = file_get_contents($this->url);
+        $response = $this->client->request(
+            'GET', $this->url, ['stream' => true]
+        );
+			
+        $rawContents = $response->getBody()->getContents();
 
         $contents = null;
         if ($this->compressionAlgo !== null) {


### PR DESCRIPTION
Solves #261 
- Get content of the report with Guzzle
- catch Exception if report is not found
- Try to automatically detect the document encoding from the http content type header. UTF-8 is the default if content type header or charset is not present.