### PR TITLE
Handle empty $encoding, solve #306

### DIFF
--- a/lib/Document.php
+++ b/lib/Document.php
@@ -136,7 +136,7 @@ class Document
                 }
                 $encoding = mb_detect_encoding($contents, $encodings, true);
             }
-            $contents = mb_convert_encoding($contents, "UTF-8", $encoding ?? mb_internal_encoding());
+            $contents = mb_convert_encoding($contents, "UTF-8", $encoding ?: mb_internal_encoding());
         }
 
         $this->tmpFilename = tempnam(sys_get_temp_dir(), "tempdoc_spapi");


### PR DESCRIPTION
solve #306
when $encoding is empty string call mb_internal_encoding() to avoid exception