### PR TITLE
Remove traling comma from Authentication.php:271

### DIFF
--- a/lib/Authentication.php
+++ b/lib/Authentication.php
@@ -268,7 +268,7 @@ class Authentication implements RequestSignerContract
                 $credentials['AccessKeyId'],
                 $credentials['SecretAccessKey'],
                 $credentials['SessionToken'],
-                $credentials['Expiration']->getTimestamp(),
+                $credentials['Expiration']->getTimestamp()
             );
         }
 


### PR DESCRIPTION
This is causing an FatalThrowableError with the following message: 'syntax error, unexpected ')'