### PR TITLE
Label : Remove 14 character count check

### DIFF
--- a/lib/Model/MerchantFulfillmentV0/Label.php
+++ b/lib/Model/MerchantFulfillmentV0/Label.php
@@ -212,10 +212,6 @@ class Label implements ModelInterface, ArrayAccess, \JsonSerializable, \Iterator
     public function listInvalidProperties()
     {
         $invalidProperties = [];
-        if (!is_null($this->container['custom_text_for_label']) && (mb_strlen($this->container['custom_text_for_label']) > 14)) {
-            $invalidProperties[] = "invalid value for 'custom_text_for_label', the character length must be smaller than or equal to 14.";
-        }
-
         if ($this->container['dimensions'] === null) {
             $invalidProperties[] = "'dimensions' can't be null";
         }
@@ -256,9 +252,6 @@ class Label implements ModelInterface, ArrayAccess, \JsonSerializable, \Iterator
      */
     public function setCustomTextForLabel($custom_text_for_label)
     {
-        if (!is_null($custom_text_for_label) && (mb_strlen($custom_text_for_label) > 14)) {
-            throw new \InvalidArgumentException('invalid length for $custom_text_for_label when calling Label., must be smaller than or equal to 14.');
-        }
 
         $this->container['custom_text_for_label'] = $custom_text_for_label;
 


### PR DESCRIPTION
From shipment labels created prior to SP-API migration, the label lenghts are greater than 14 characters. This mean when calling getShipment() we get a validation error.

I propose removing these checks