### PR TITLE
Update ObjectSerializer.php

### DIFF
--- a/lib/ObjectSerializer.php
+++ b/lib/ObjectSerializer.php
@@ -262,7 +262,7 @@ class ObjectSerializer
         }
 
         if (strcasecmp(substr($class, -2), '[]') === 0) {
-            $data = is_string($data) ? json_decode($data) : $data;
+            $data = is_string($data) ? json_decode($data, true) : $data;
             
             if (!is_array($data)) {
                 throw new \InvalidArgumentException("Invalid array '$class'");


### PR DESCRIPTION
For shipping API v2 whenever there is an error response from the amazon side then the deserialization is not done properly and shows the PHP error as given in the below issue link.

This will show the API error instead of the PHP error.

https://github.com/jlevers/selling-partner-api/issues/368

