### PR TITLE
Some locales/regions have a possibility to return a non-upper case va…

### DIFF
--- a/lib/Model/CatalogItemsV20220401/ItemImage.php
+++ b/lib/Model/CatalogItemsV20220401/ItemImage.php
@@ -244,7 +244,7 @@ class ItemImage implements ModelInterface, ArrayAccess, \JsonSerializable, \Iter
             $invalidProperties[] = "'variant' can't be null";
         }
         $allowedValues = $this->getVariantAllowableValues();
-        if (!is_null($this->container['variant']) && !in_array($this->container['variant'], $allowedValues, true)) {
+        if (!is_null($this->container['variant']) && !in_array(strtoupper($this->container['variant']), $allowedValues, true)) {
             $invalidProperties[] = sprintf(
                 "invalid value '%s' for 'variant', must be one of '%s'",
                 $this->container['variant'],
@@ -296,7 +296,7 @@ class ItemImage implements ModelInterface, ArrayAccess, \JsonSerializable, \Iter
     public function setVariant($variant)
     {
         $allowedValues = $this->getVariantAllowableValues();
-        if (!in_array($variant, $allowedValues, true)) {
+        if (!in_array(strtoupper($variant), $allowedValues, true)) {
             throw new \InvalidArgumentException(
                 sprintf(
                     "Invalid value '%s' for 'variant', must be one of '%s'",


### PR DESCRIPTION
…riant ex. 'Main' instead of MAIN. As for a workaround for the allowedValues for this property, we convert the SPAPI provided variant to uppercase to allow a little flexibility for Amazon's shenanigans.