### PR TITLE
Fix double quote parsing in Document class for GET_LEDGER_SUMMARY_VIEW_DATA

### DIFF
--- a/lib/Document.php
+++ b/lib/Document.php
@@ -162,8 +162,8 @@ class Document
                 // results in the default enclosure being used (a double quote character), so we use a
                 // bizarre character to avoid recognizing double quotes as enclosures.
                 // Thanks @gregordonsky (https://github.com/gregordonsky) for the idea!
-                // Keep default enclosure for GET_LEDGER_DETAIL_VIEW_DATA as Amazon is sending with quotes
-                if($this->reportName !== "GET_LEDGER_DETAIL_VIEW_DATA") {
+                // Keep default enclosure for GET_LEDGER_DETAIL_VIEW_DATA and GET_LEDGER_SUMMARY_VIEW_DATA as Amazon is sending with quotes
+                if($this->reportName !== "GET_LEDGER_DETAIL_VIEW_DATA" && $this->reportName !== "GET_LEDGER_SUMMARY_VIEW_DATA") {
                     $reader->setEnclosure(chr(8));
                 }
                 // no break


### PR DESCRIPTION
I'm using GET_LEDGER_SUMMARY_VIEW_DATA and it has the same problem with double quotes as GET_LEDGER_DETAIL_VIEW_DATA.
See screenshots
![current behaviour](https://user-images.githubusercontent.com/5500081/235729177-3ccca536-505d-4781-83de-4eb1c7b89625.png)
![fixed behaviour](https://user-images.githubusercontent.com/5500081/235729190-b0d54354-39d9-42dc-a3a3-4f188cbb1409.png)
