### PR TITLE
Update HeaderSelector when configuration changes

### DIFF
--- a/lib/Api/BaseApi.php
+++ b/lib/Api/BaseApi.php
@@ -55,6 +55,7 @@ abstract class BaseApi
     public function setConfig(Configuration $config)
     {
         $this->config = $config;
+        $this->headerSelector = new HeaderSelector($config);
         return $this;
     }
 


### PR DESCRIPTION
I've been using the multi version of the laravel library. Whenever a seller region was not NA, I got a "403 forbidden". Tracking it down, I noticed, that the laravel lib initially loads the "HeaderSelector" with the default config.

When you call an APIs (or `BaseAPI`s) `setConfig` method, the new configuration applies, including the new region. But, as the HeaderSelector still references the 'old' config with region NA, a wrong 'Host' header will be set. Therefore the request signing process is wrong and ends in a 403, whenever the region is not NA.