### PR TITLE
remove no message exception

### DIFF
--- a/lib/Model/AplusContentV20201101/Error.php
+++ b/lib/Model/AplusContentV20201101/Error.php
@@ -208,11 +208,6 @@ class Error extends BaseModel implements ModelInterface, ArrayAccess, \JsonSeria
      */
     public function setMessage($message)
     {
-
-        if ((mb_strlen($message) < 1)) {
-            throw new \InvalidArgumentException('invalid length for $message when calling Error., must be bigger than or equal to 1.');
-        }
-
         $this->container['message'] = $message;
 
         return $this;


### PR DESCRIPTION
There are some situations that don't have a message, for example, if you try to get rejected document `getContentDocument`

example response

```json
{
  "warnings": [
    {
      "code": "CONTENT_REJECTED",
      "message": "",
      "details": "Claims (e.g., recommended by, certified, tested, approved, proven, validated, etc) and awards must be substantiated by a note in the text with certifying or awarding body, study, publication, or other evidence, and year. Awards must have been granted in the last two years."
    },
    {
      "code": "CONTENT_REJECTED",
      "message": "",
      "details": "Please do not use informal or boastful marketing language (e.g., most amazing new product, etc) when addressing the customer. Claims of leadership or top rating must be substantiated by a note in the text with a study, publication, or other evidence, and year."
    },
    {
      "code": "CONTENT_REJECTED",
      "message": "",
      "details": "Before publishing this submission we need you to do some editing:############"
    }
  ],
  "contentRecord": {
    "contentReferenceKey": "#######",
    "contentMetadata": {
      "name": "#######",
      "marketplaceId": "ATVPDKIKX0DER",
      "status": "REJECTED",
      "badgeSet": [
        "STANDARD"
      ],
      "updateTime": "2022-03-21T17:33:38.82Z"
    },
    "contentDocument": null
  }
}
```