### PR TITLE
add a CurrencyCode JPY

### DIFF
--- a/lib/Model/FbaInboundV0/CurrencyCode.php
+++ b/lib/Model/FbaInboundV0/CurrencyCode.php
@@ -50,6 +50,7 @@ class CurrencyCode
     const GBP = 'GBP';
     const EUR = 'EUR';
     const PLN = 'PLN';
+    const JPY = 'JPY';
     
     /**
      * Gets allowable values of the enum
@@ -63,6 +64,7 @@ class CurrencyCode
             self::GBP,
             self::EUR,
             self::PLN,
+            self::JPY,
         ];
         // This is necessary because Amazon does not consistently capitalize their
         // enum values, so we do case-insensitive enum value validation in ObjectSerializer


### PR DESCRIPTION
I am a seller from Japan and I use this library.
When I used the FBA Inbound API v0 Operation: getPrepInstructions, it couldn't process the Currency Code JPY and I encountered the following error:

```Error - Invalid value for enum '\SellingPartnerApi\Model\FbaInboundV0\CurrencyCode', must be one of: 'CAD', 'USD', 'GBP', 'EUR', 'PLN', 'CAD', 'USD', 'GBP', 'EUR', 'PLN' in /var/www/html/vendor/jlevers/selling-partner-api/lib/ObjectSerializer.php on line 360```

I've made corrections for this to work. Please review.