### PR TITLE
Adds missing KZ_VOEC deemedResellerCategory

### DIFF
--- a/lib/Model/OrdersV0/OrderItem.php
+++ b/lib/Model/OrdersV0/OrderItem.php
@@ -283,6 +283,7 @@ class OrderItem extends BaseModel implements ModelInterface, ArrayAccess, \JsonS
     const DEEMED_RESELLER_CATEGORY_AU_VOEC = 'AU_VOEC';
     const DEEMED_RESELLER_CATEGORY_NZ_VOEC = 'NZ_VOEC';
     const DEEMED_RESELLER_CATEGORY_JE_VOEC = 'JE_VOEC';
+    const DEEMED_RESELLER_CATEGORY_KZ_VOEC = 'KZ_VOEC';
     const DEEMED_RESELLER_CATEGORY_CH_SUPPLIER_IMPORT = 'CH_SUPPLIER_IMPORT';
     
     
@@ -304,6 +305,7 @@ class OrderItem extends BaseModel implements ModelInterface, ArrayAccess, \JsonS
             self::DEEMED_RESELLER_CATEGORY_AU_VOEC,
             self::DEEMED_RESELLER_CATEGORY_NZ_VOEC,
             self::DEEMED_RESELLER_CATEGORY_JE_VOEC,
+            self::DEEMED_RESELLER_CATEGORY_KZ_VOEC,
             self::DEEMED_RESELLER_CATEGORY_CH_SUPPLIER_IMPORT,
         ];
 


### PR DESCRIPTION
Adds missing value for deemed reseller category as requested on https://github.com/jlevers/selling-partner-api/issues/466#issuecomment-1385368102

I experienced similar value on my end.