### PR TITLE
added required parameters to trigger creation of rdt on createShippingRequest method

### DIFF
--- a/lib/Api/VendorDirectFulfillmentShippingV20211228Api.php
+++ b/lib/Api/VendorDirectFulfillmentShippingV20211228Api.php
@@ -70,7 +70,10 @@ class VendorDirectFulfillmentShippingV20211228Api extends BaseApi
     {
         $request = $this->createShippingLabelsRequest($purchase_order_number, $body);
         $signedRequest = $this->config->signRequest(
-            $request
+            $request,
+            null,
+            '/vendor/directFulfillment/shipping/2021-12-28/shippingLabels/{purchaseOrderNumber}',
+            'createShippingLabels'
         );
 
         $this->writeDebug($signedRequest);


### PR DESCRIPTION
I'm not sure if the expectation is that we create a whole new requestSigner and pass that into the Config. But this request needs a RDT and this package is supposed to automatically create these for requests that require them. Am I doing something wrong?