### PR TITLE
Add support for NG_VOEC Deemed Reseller Category

### DIFF
--- a/lib/Model/OrdersV0/OrderItem.php
+++ b/lib/Model/OrdersV0/OrderItem.php
@@ -282,6 +282,7 @@ class OrderItem extends BaseModel implements ModelInterface, ArrayAccess, \JsonS
     const DEEMED_RESELLER_CATEGORY_CA_MPF = 'CA_MPF';
     const DEEMED_RESELLER_CATEGORY_AU_VOEC = 'AU_VOEC';
     const DEEMED_RESELLER_CATEGORY_NZ_VOEC = 'NZ_VOEC';
+    const DEEMED_RESELLER_CATEGORY_NG_VOEC = 'NG_VOEC';
     const DEEMED_RESELLER_CATEGORY_JE_VOEC = 'JE_VOEC';
     const DEEMED_RESELLER_CATEGORY_CH_SUPPLIER_IMPORT = 'CH_SUPPLIER_IMPORT';
     
@@ -303,6 +304,7 @@ class OrderItem extends BaseModel implements ModelInterface, ArrayAccess, \JsonS
             self::DEEMED_RESELLER_CATEGORY_CA_MPF,
             self::DEEMED_RESELLER_CATEGORY_AU_VOEC,
             self::DEEMED_RESELLER_CATEGORY_NZ_VOEC,
+            self::DEEMED_RESELLER_CATEGORY_NG_VOEC,
             self::DEEMED_RESELLER_CATEGORY_JE_VOEC,
             self::DEEMED_RESELLER_CATEGORY_CH_SUPPLIER_IMPORT,
         ];


### PR DESCRIPTION
Hello there!

Thank you for your library.
For one of the sellers we receive an error report with the following text:

```
Invalid value 'NG_VOEC' for 'deemed_reseller_category', must be one of 'IOSS', 'UOSS', 'SG_VOEC', 'GB_VOEC', 'NO_VOEC', 'CA_MPF', 'AU_VOEC', 'NZ_VOEC', 'JE_VOEC', 'CH_SUPPLIER_IMPORT'
```

From what I understand it's needed to tune a bit `getDeemedResellerCategoryAllowableValues`

Could you please check my PR and sync it upstream if you have time? Thank you!
