### PR TITLE
Added support for GARAGE/OTHER DOOR/OTHER LOC

### DIFF
--- a/lib/Model/FbaOutboundV20200701/AdditionalLocationInfo.php
+++ b/lib/Model/FbaOutboundV20200701/AdditionalLocationInfo.php
@@ -74,7 +74,8 @@ class AdditionalLocationInfo
     const RECEIVER = 'RECEIVER';
     const SECURE_LOCATION = 'SECURE_LOCATION';
     const SIDE_DOOR = 'SIDE_DOOR';
-    
+    const GARAGE_OTHER_LOC = 'GARAGE/OTHER DOOR/OTHER LOC';
+
     /**
      * Gets allowable values of the enum
      * @return string[]
@@ -111,6 +112,7 @@ class AdditionalLocationInfo
             self::RECEIVER,
             self::SECURE_LOCATION,
             self::SIDE_DOOR,
+            self::GARAGE_OTHER_LOC,
         ];
         // This is necessary because Amazon does not consistently capitalize their
         // enum values, so we do case-insensitive enum value validation in ObjectSerializer


### PR DESCRIPTION
This change fixes #652.

We faced this error because an order used GARAGE/OTHER DOOR/OTHER LOC in additionalLocationInfo and the library crashed when that order was deserialized.