### PR TITLE
Simplify logging of exceptions, requests and responses.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "jlevers/selling-partner-api",
-    "version": "5.10.2",
+    "version": "5.10.3",
     "description": "PHP client for Amazon's Selling Partner API",
     "keywords": [
         "api",

--- a/lib/Api/BaseApi.php
+++ b/lib/Api/BaseApi.php
@@ -87,9 +87,18 @@ abstract class BaseApi
     protected function writeDebug($data)
     {
         if ($this->config->getDebug()) {
+            if ($data instanceof Throwable) {
+                $data = "$data";
+            } else if ($data instanceof GuzzleHttp\Psr7\Request) {
+                $data = "{$data->getMethod()} {$data->getUri()}\n" . implode("\n", $data->getHeaders());
+            } else if ($data instanceof GuzzleHttp\Psr7\Response) {
+                $data = "{$data->getStatusCode()} {$data->getReasonPhrase()}\n" . implode("\n", $data->getHeaders());
+            } else {
+                $data = print_r($data, true);
+            }
             file_put_contents(
                 $this->config->getDebugFile(),
-                '[' . date('Y-m-d H:i:s') . ']: ' . print_r($data, true) . "\n",
+                '[' . date('Y-m-d H:i:s') . ']: ' . $data . "\n",
                 FILE_APPEND
             );
         }

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -56,7 +56,7 @@ class Configuration
      *
      * @var string
      */
-    protected $userAgent = 'jlevers/selling-partner-api/5.10.2 (Language=PHP)';
+    protected $userAgent = 'jlevers/selling-partner-api/5.10.3 (Language=PHP)';
 
     /**
      * Debug switch (default set to false)
@@ -429,7 +429,7 @@ class Configuration
         $report .= '    OS: ' . php_uname() . PHP_EOL;
         $report .= '    PHP Version: ' . PHP_VERSION . PHP_EOL;
         $report .= '    The version of the OpenAPI document: 2020-11-01' . PHP_EOL;
-        $report .= '    SDK Package Version: 5.10.2' . PHP_EOL;
+        $report .= '    SDK Package Version: 5.10.3' . PHP_EOL;
         $report .= '    Temp Folder Path: ' . $tempFolderPath . PHP_EOL;
 
         return $report;


### PR DESCRIPTION
The current logging uses print_r which produces a very verbose result. This simplifies the logging for the common cases so the logs are easier to read.

Resubmitted to v5.0 branch