### PR TITLE
Fix \DateTime serialization of requests.

### DIFF
--- a/src/Traits/HasArrayableAttributes.php
+++ b/src/Traits/HasArrayableAttributes.php
@@ -60,7 +60,7 @@ trait HasArrayableAttributes
         if (is_null($value)) {
             return null;
         } elseif ($value instanceof DateTime) {
-            return $value->format(DateTime::RFC3339);
+            return $this->toZuluString($value);
         } elseif (is_string($type)) {
             if (class_exists($type)) {
                 return $value->toArray();
@@ -85,5 +85,13 @@ trait HasArrayableAttributes
         }
 
         throw new InvalidAttributeTypeException("Unrecognized attribute type `$type`");
+    }
+
+    private function toZuluString(\DateTime $dateTime)
+    {
+        $dt = clone $dateTime;
+        $dt->setTimezone(new \DateTimeZone("UTC"));
+
+        return $dt->format('Y-m-d\TH:i:s\Z');
     }
 }


### PR DESCRIPTION
Changed formatting from DateTime::RFC3339 ('Y-m-d\TH:i:sP') to ZULU ('Y-m-d\TH:i:s\Z') Fixes #698