### PR TITLE
Fix incorrect parameter checks inside searchCatalogItemsRequest

### DIFF
--- a/lib/Api/CatalogItemsV20220401Api.php
+++ b/lib/Api/CatalogItemsV20220401Api.php
@@ -853,15 +853,15 @@ class CatalogItemsV20220401Api extends BaseApi
                 'Missing the required parameter $marketplace_ids when calling searchCatalogItems'
             );
         }
-        if (count($marketplace_ids) > 1) {
+        if (count( explode(",", $marketplace_ids) ) > 1) {
             throw new \InvalidArgumentException('invalid value for "$marketplace_ids" when calling CatalogItemsV20220401Api.searchCatalogItems, number of items must be less than or equal to 1.');
         }
 
-        if ($identifiers !== null && count($identifiers) > 20) {
+        if ($identifiers !== null && count( explode(",", $identifiers) ) > 20) {
             throw new \InvalidArgumentException('invalid value for "$identifiers" when calling CatalogItemsV20220401Api.searchCatalogItems, number of items must be less than or equal to 20.');
         }
 
-        if ($keywords !== null && count($keywords) > 20) {
+        if ($keywords !== null && count( explode(",", $keywords) ) > 20) {
             throw new \InvalidArgumentException('invalid value for "$keywords" when calling CatalogItemsV20220401Api.searchCatalogItems, number of items must be less than or equal to 20.');
         }
 


### PR DESCRIPTION
keywords, identifiers, and marketplace_ids can each be comma-separated strings that have a limit on values. The code was trying to use count() to check for that, which doesn't work. I added explode(",", $var) to fix this.

Imo, it would make more sense if these parameters were typed as arrays to begin with, but making a change like that would break existing implementations. This method was chosen so it will "just work" for anyone's existing usage of the library.