### PR TITLE
Remove Shipment Address required values

### DIFF
--- a/resources/metadata/modifications.json
+++ b/resources/metadata/modifications.json
@@ -6,6 +6,14 @@
           "comment": "Responses from Amazon have been missing one or more required Address parts",
           "action": "delete",
           "path": "components.schemas.Address.required"
+        },
+        {
+          "comment": "Responses from Amazon do not have the AreCasesRequired value",
+          "action": "replace",
+          "path": "components.schemas.InboundShipmentInfo.required",
+          "value": [
+            "ShipFromAddress"
+          ]
         }
       ]
     },

--- a/resources/metadata/modifications.json
+++ b/resources/metadata/modifications.json
@@ -1,5 +1,14 @@
 {
   "seller": {
+    "fba-inbound": {
+      "0": [
+        {
+          "comment": "Responses from Amazon have been missing one or more required Address parts",
+          "action": "delete",
+          "path": "components.schemas.Address.required"
+        }
+      ]
+    },
     "fba-outbound": {
       "2020-07-01": [
         {

--- a/resources/models/seller/fba-inbound/v0.json
+++ b/resources/models/seller/fba-inbound/v0.json
@@ -5530,7 +5530,6 @@
             },
             "InboundShipmentInfo": {
                 "required": [
-                    "AreCasesRequired",
                     "ShipFromAddress"
                 ],
                 "type": "object",

--- a/resources/models/seller/fba-inbound/v0.json
+++ b/resources/models/seller/fba-inbound/v0.json
@@ -4808,14 +4808,6 @@
                 }
             },
             "Address": {
-                "required": [
-                    "AddressLine1",
-                    "City",
-                    "CountryCode",
-                    "Name",
-                    "PostalCode",
-                    "StateOrProvinceCode"
-                ],
                 "type": "object",
                 "properties": {
                     "Name": {

--- a/src/Seller/FBAInboundV0/Dto/Address.php
+++ b/src/Seller/FBAInboundV0/Dto/Address.php
@@ -17,37 +17,37 @@ final class Address extends Dto
     protected static array $attributeMap = [
         'name' => 'Name',
         'addressLine1' => 'AddressLine1',
+        'addressLine2' => 'AddressLine2',
+        'districtOrCounty' => 'DistrictOrCounty',
         'city' => 'City',
         'stateOrProvinceCode' => 'StateOrProvinceCode',
         'countryCode' => 'CountryCode',
         'postalCode' => 'PostalCode',
-        'addressLine2' => 'AddressLine2',
-        'districtOrCounty' => 'DistrictOrCounty',
     ];
 
     /**
-     * @param  string  $name  Name of the individual or business.
-     * @param  string  $addressLine1  The street address information.
-     * @param  string  $city  The city.
-     * @param  string  $stateOrProvinceCode  The state or province code.
-     *
-     * If state or province codes are used in your marketplace, it is recommended that you include one with your request. This helps Amazon to select the most appropriate Amazon fulfillment center for your inbound shipment plan.
-     * @param  string  $countryCode  The country code in two-character ISO 3166-1 alpha-2 format.
-     * @param  string  $postalCode  The postal code.
-     *
-     * If postal codes are used in your marketplace, we recommended that you include one with your request. This helps Amazon select the most appropriate Amazon fulfillment center for the inbound shipment plan.
+     * @param  ?string  $name  Name of the individual or business.
+     * @param  ?string  $addressLine1  The street address information.
      * @param  ?string  $addressLine2  Additional street address information, if required.
      * @param  ?string  $districtOrCounty  The district or county.
+     * @param  ?string  $city  The city.
+     * @param  ?string  $stateOrProvinceCode  The state or province code.
+     *
+     * If state or province codes are used in your marketplace, it is recommended that you include one with your request. This helps Amazon to select the most appropriate Amazon fulfillment center for your inbound shipment plan.
+     * @param  ?string  $countryCode  The country code in two-character ISO 3166-1 alpha-2 format.
+     * @param  ?string  $postalCode  The postal code.
+     *
+     * If postal codes are used in your marketplace, we recommended that you include one with your request. This helps Amazon select the most appropriate Amazon fulfillment center for the inbound shipment plan.
      */
     public function __construct(
-        public readonly string $name,
-        public readonly string $addressLine1,
-        public readonly string $city,
-        public readonly string $stateOrProvinceCode,
-        public readonly string $countryCode,
-        public readonly string $postalCode,
+        public readonly ?string $name = null,
+        public readonly ?string $addressLine1 = null,
         public readonly ?string $addressLine2 = null,
         public readonly ?string $districtOrCounty = null,
+        public readonly ?string $city = null,
+        public readonly ?string $stateOrProvinceCode = null,
+        public readonly ?string $countryCode = null,
+        public readonly ?string $postalCode = null,
     ) {
     }
 }

--- a/src/Seller/FBAInboundV0/Dto/InboundShipmentInfo.php
+++ b/src/Seller/FBAInboundV0/Dto/InboundShipmentInfo.php
@@ -16,12 +16,12 @@ final class InboundShipmentInfo extends Dto
 {
     protected static array $attributeMap = [
         'shipFromAddress' => 'ShipFromAddress',
-        'areCasesRequired' => 'AreCasesRequired',
         'shipmentId' => 'ShipmentId',
         'shipmentName' => 'ShipmentName',
         'destinationFulfillmentCenterId' => 'DestinationFulfillmentCenterId',
         'shipmentStatus' => 'ShipmentStatus',
         'labelPrepType' => 'LabelPrepType',
+        'areCasesRequired' => 'AreCasesRequired',
         'confirmedNeedByDate' => 'ConfirmedNeedByDate',
         'boxContentsSource' => 'BoxContentsSource',
         'estimatedBoxContentsFee' => 'EstimatedBoxContentsFee',
@@ -29,24 +29,24 @@ final class InboundShipmentInfo extends Dto
 
     /**
      * @param  Address  $shipFromAddress  Specific details to identify a place.
-     * @param  bool  $areCasesRequired  Indicates whether or not an inbound shipment contains case-packed boxes. When AreCasesRequired = true for an inbound shipment, all items in the inbound shipment must be case packed.
      * @param  ?string  $shipmentId  The shipment identifier submitted in the request.
      * @param  ?string  $shipmentName  The name for the inbound shipment.
      * @param  ?string  $destinationFulfillmentCenterId  An Amazon fulfillment center identifier created by Amazon.
      * @param  ?string  $shipmentStatus  Indicates the status of the inbound shipment. When used with the createInboundShipment operation, WORKING is the only valid value. When used with the updateInboundShipment operation, possible values are WORKING, SHIPPED or CANCELLED.
      * @param  ?string  $labelPrepType  The type of label preparation that is required for the inbound shipment.
+     * @param  ?bool  $areCasesRequired  Indicates whether or not an inbound shipment contains case-packed boxes. When AreCasesRequired = true for an inbound shipment, all items in the inbound shipment must be case packed.
      * @param  ?\DateTimeInterface  $confirmedNeedByDate  Type containing date in string format
      * @param  ?string  $boxContentsSource  Where the seller provided box contents information for a shipment.
      * @param  ?BoxContentsFeeDetails  $estimatedBoxContentsFee  The manual processing fee per unit and total fee for a shipment.
      */
     public function __construct(
         public readonly Address $shipFromAddress,
-        public readonly bool $areCasesRequired,
         public readonly ?string $shipmentId = null,
         public readonly ?string $shipmentName = null,
         public readonly ?string $destinationFulfillmentCenterId = null,
         public readonly ?string $shipmentStatus = null,
         public readonly ?string $labelPrepType = null,
+        public readonly ?bool $areCasesRequired = null,
         public readonly ?\DateTimeInterface $confirmedNeedByDate = null,
         public readonly ?string $boxContentsSource = null,
         public readonly ?BoxContentsFeeDetails $estimatedBoxContentsFee = null,


### PR DESCRIPTION
Data fetched from Amazon for shipments can be missing values. This results in deserialisation errors when Amazon returns data with those fields missing.

Fixes #703