### PR TITLE
Handle boolean parameters

### DIFF
--- a/src/SellingPartnerApi.php
+++ b/src/SellingPartnerApi.php
@@ -51,6 +51,8 @@ class SellingPartnerApi extends Connector
             if (is_array($value)) {
                 $stringified = array_map(fn ($v) => urlencode((string) $v), $value);
                 $csvQuery[$key] = implode(',', $stringified);
+            } elseif (is_bool($value)) {
+                $csvQuery[$key] = $value ? 'true' : 'false';
             } else {
                 $csvQuery[$key] = urlencode((string) $value);
             }


### PR DESCRIPTION
Boolean parameters were being converted into `1` or `0` rather than `true` or `false`. This commit handles boolean values and turns them into the correct string value.

Should fix #702