### PR TITLE
Added a modification to the catalog-items 2022 data, Pagination and Refinements must be nullable.

### DIFF
--- a/resources/metadata/modifications.json
+++ b/resources/metadata/modifications.json
@@ -73,6 +73,19 @@
           ]
         }
       ]
+    },
+    "catalog-items": {
+      "2022-04-01": [
+        {
+          "comment": "Remove required 'Pagination' and 'Refinements', see https://github.com/jlevers/selling-partner-api/issues/740",
+          "action": "replace",
+          "path": "components.schemas.ItemSearchResults.required",
+          "value": [
+            "items",
+            "numberOfResults"
+          ]
+        }
+      ]
     }
   }
 }

--- a/resources/models/seller/catalog-items/v2022-04-01.json
+++ b/resources/models/seller/catalog-items/v2022-04-01.json
@@ -4111,9 +4111,7 @@
             "ItemSearchResults": {
                 "required": [
                     "items",
-                    "numberOfResults",
-                    "pagination",
-                    "refinements"
+                    "numberOfResults"
                 ],
                 "type": "object",
                 "properties": {

--- a/src/Seller/CatalogItemsV20220401/Responses/ItemSearchResults.php
+++ b/src/Seller/CatalogItemsV20220401/Responses/ItemSearchResults.php
@@ -16,20 +16,22 @@ use SellingPartnerApi\Seller\CatalogItemsV20220401\Dto\Refinements;
 
 final class ItemSearchResults extends Response
 {
-    protected static array $complexArrayTypes = ['items' => [Item::class]];
+	protected static array $complexArrayTypes = ['items' => [Item::class]];
 
-    /**
-     * @param  int  $numberOfResults  For `identifiers`-based searches, the total number of Amazon catalog items found. For `keywords`-based searches, the estimated total number of Amazon catalog items matched by the search query (only results up to the page count limit will be returned per request regardless of the number found).
-     *
-     * Note: The maximum number of items (ASINs) that can be returned and paged through is 1000.
-     * @param  Pagination  $pagination  When a request produces a response that exceeds the `pageSize`, pagination occurs. This means the response is divided into individual pages. To retrieve the next page or the previous page, you must pass the `nextToken` value or the `previousToken` value as the `pageToken` parameter in the next request. When you receive the last page, there will be no `nextToken` key in the pagination object.
-     * @param  Refinements  $refinements  Search refinements.
-     * @param  Item[]  $items  A list of items from the Amazon catalog.
-     */
-    public function __construct(
-        public readonly int $numberOfResults,
-        public readonly Pagination $pagination,
-        public readonly Refinements $refinements,
-        public readonly array $items,
-    ) {}
+
+	/**
+	 * @param int $numberOfResults For `identifiers`-based searches, the total number of Amazon catalog items found. For `keywords`-based searches, the estimated total number of Amazon catalog items matched by the search query (only results up to the page count limit will be returned per request regardless of the number found).
+	 *
+	 * Note: The maximum number of items (ASINs) that can be returned and paged through is 1000.
+	 * @param Item[] $items A list of items from the Amazon catalog.
+	 * @param ?Pagination $pagination When a request produces a response that exceeds the `pageSize`, pagination occurs. This means the response is divided into individual pages. To retrieve the next page or the previous page, you must pass the `nextToken` value or the `previousToken` value as the `pageToken` parameter in the next request. When you receive the last page, there will be no `nextToken` key in the pagination object.
+	 * @param ?Refinements $refinements Search refinements.
+	 */
+	public function __construct(
+		public readonly int $numberOfResults,
+		public readonly array $items,
+		public readonly ?Pagination $pagination = null,
+		public readonly ?Refinements $refinements = null,
+	) {
+	}
 }

--- a/src/Seller/CatalogItemsV20220401/Responses/ItemSearchResults.php
+++ b/src/Seller/CatalogItemsV20220401/Responses/ItemSearchResults.php
@@ -16,22 +16,20 @@ use SellingPartnerApi\Seller\CatalogItemsV20220401\Dto\Refinements;
 
 final class ItemSearchResults extends Response
 {
-	protected static array $complexArrayTypes = ['items' => [Item::class]];
+    protected static array $complexArrayTypes = ['items' => [Item::class]];
 
-
-	/**
-	 * @param int $numberOfResults For `identifiers`-based searches, the total number of Amazon catalog items found. For `keywords`-based searches, the estimated total number of Amazon catalog items matched by the search query (only results up to the page count limit will be returned per request regardless of the number found).
-	 *
-	 * Note: The maximum number of items (ASINs) that can be returned and paged through is 1000.
-	 * @param Item[] $items A list of items from the Amazon catalog.
-	 * @param ?Pagination $pagination When a request produces a response that exceeds the `pageSize`, pagination occurs. This means the response is divided into individual pages. To retrieve the next page or the previous page, you must pass the `nextToken` value or the `previousToken` value as the `pageToken` parameter in the next request. When you receive the last page, there will be no `nextToken` key in the pagination object.
-	 * @param ?Refinements $refinements Search refinements.
-	 */
-	public function __construct(
-		public readonly int $numberOfResults,
-		public readonly array $items,
-		public readonly ?Pagination $pagination = null,
-		public readonly ?Refinements $refinements = null,
-	) {
-	}
+    /**
+     * @param  int  $numberOfResults  For `identifiers`-based searches, the total number of Amazon catalog items found. For `keywords`-based searches, the estimated total number of Amazon catalog items matched by the search query (only results up to the page count limit will be returned per request regardless of the number found).
+     *
+     * Note: The maximum number of items (ASINs) that can be returned and paged through is 1000.
+     * @param  Item[]  $items  A list of items from the Amazon catalog.
+     * @param  ?Pagination  $pagination  When a request produces a response that exceeds the `pageSize`, pagination occurs. This means the response is divided into individual pages. To retrieve the next page or the previous page, you must pass the `nextToken` value or the `previousToken` value as the `pageToken` parameter in the next request. When you receive the last page, there will be no `nextToken` key in the pagination object.
+     * @param  ?Refinements  $refinements  Search refinements.
+     */
+    public function __construct(
+        public readonly int $numberOfResults,
+        public readonly array $items,
+        public readonly ?Pagination $pagination = null,
+        public readonly ?Refinements $refinements = null,
+    ) {}
 }


### PR DESCRIPTION
Fix for this issue: https://github.com/jlevers/selling-partner-api/issues/740