### PR TITLE
Fixes https://github.com/jlevers/selling-partner-api/issues/758

### DIFF
--- a/src/Seller/CatalogItemsV20220401/Dto/ItemSummaryByMarketplace.php
+++ b/src/Seller/CatalogItemsV20220401/Dto/ItemSummaryByMarketplace.php
@@ -14,7 +14,7 @@ use SellingPartnerApi\Dto;
 
 final class ItemSummaryByMarketplace extends Dto
 {
-    protected static array $complexArrayTypes = ['contributors' => ItemContributor::class];
+    protected static array $complexArrayTypes = ['contributors' => [ItemContributor::class]];
 
     /**
      * @param  string  $marketplaceId  Amazon marketplace identifier.
@@ -31,7 +31,7 @@ final class ItemSummaryByMarketplace extends Dto
      * @param  ?string  $modelNumber  Model number associated with an Amazon catalog item.
      * @param  ?int  $packageQuantity  Quantity of an Amazon catalog item in one package.
      * @param  ?string  $partNumber  Part number associated with an Amazon catalog item.
-     * @param  ?\DateTimeInterface  $releaseDate  First date on which an Amazon catalog item is shippable to customers.
+     * @param  \DateTime|false|null  $releaseDate  First date on which an Amazon catalog item is shippable to customers.
      * @param  ?string  $size  Name of the size associated with an Amazon catalog item.
      * @param  ?string  $style  Name of the style associated with an Amazon catalog item.
      * @param  ?bool  $tradeInEligible  Identifies an Amazon catalog item is eligible for trade-in.
@@ -53,11 +53,12 @@ final class ItemSummaryByMarketplace extends Dto
         public readonly ?string $modelNumber = null,
         public readonly ?int $packageQuantity = null,
         public readonly ?string $partNumber = null,
-        public readonly ?\DateTimeInterface $releaseDate = null,
+        public readonly \DateTime|false|null $releaseDate = null,
         public readonly ?string $size = null,
         public readonly ?string $style = null,
         public readonly ?bool $tradeInEligible = null,
         public readonly ?string $websiteDisplayGroup = null,
         public readonly ?string $websiteDisplayGroupName = null,
-    ) {}
-}
+        ) {
+        }
+    }


### PR DESCRIPTION
Look. I'm not great at coding. But this works.

It allows `SellingPartnerApi->seller()->catalogItems->catalogApi->getCatalogItem()` to work, getting around the 'datetime cannot be false' issue via the use of 'Union' types.

Accepting this PR would probably break a lot of things that I'm not aware of.

But it doesn't give me any errors.

So I'm putting this here, so other coders can add to this.