### PR TITLE
fix: Update datetime format

### DIFF
--- a/src/Traits/HasArrayableAttributes.php
+++ b/src/Traits/HasArrayableAttributes.php
@@ -12,7 +12,7 @@ trait HasArrayableAttributes
 {
     use HasComplexArrayTypes;
 
-    protected static string $datetimeFormat = 'Y-m-d\TH:i:s\Z';
+    protected static string $datetimeFormat = 'Y-m-d\TH:i:s.v\Z';
 
     /**
      * @var array{string, string}

--- a/tests/SerializationTest.php
+++ b/tests/SerializationTest.php
@@ -165,6 +165,6 @@ class SerializationTest extends TestCase
 
         $body = $mockClient->getLastPendingRequest()->body()->all();
 
-        $this->assertEquals('2024-01-01T00:00:00Z', $body['packageDetail']['shipDate']);
+        $this->assertEquals('2024-01-01T00:00:00.000Z', $body['packageDetail']['shipDate']);
     }
 }


### PR DESCRIPTION
It looks like we are using the wrong datetime format when sending requests to the amazon api.

From amazon documentation:

> Amazon Selling Partner API (SP-API) formats date and time data similar to the RFC 3339 standard, which defines a subset profile of ISO 8601 for use in internet protocols and standards. This section will clarify how to format and use date and time data in SP-API.
>
> ### Type DateTime
>
> Date and time data is expressed as Gregorian calendar dates (year, month, day) and 24-hour time. No truncated formats are allowed. All date and time data is expressed numerically with leading zeros preserved.
>
> DateTime string patterns are yyyy-MM-ddTHH:mm:ss.sssZ (for UTC) or yyyy-MM-ddTHH:mm:ss.sss±hh:mm (for a local time offset). The character T is a required delimiter between the date and time sections. The colon (:) is used as a delimiter between hours, minutes, and seconds. Fractional seconds are expressed with a decimal mark (. or ,) when needed.

https://developer-docs.amazon.com/sp-api/docs/iso-8601


Currently we are using format: `Y-m-d\TH:i:s\Z` - for example `2024-08-23T07:12:34Z` but it is not compliant with the docs, where fractional seconds are expected as well - like: `2024-08-23T07:12:34.000Z`.


I have notice the issue when switching from v5 to v7 and executed some test with Amazon Sandbox API.
Here is the example request to `/vendor/payments/v1/invoices`

In v5 the request body was:

```json
{"invoices":[{"invoiceType":"Invoice","id":"TestInvoice1","date":"2024-08-23T07:12:34.000Z","remitToParty":{"partyId":"ABCDE"},"invoiceTotal":{"currencyCode":"USD","amount":"112.05"},"shipFromParty":{"partyId":"TES1"},"billToParty":{"partyId":"TES1"}}]}
```

and in v7 it is:

```json
{"invoices":[{"invoiceType":"Invoice","id":"TestInvoice1","date":"2024-08-23T07:12:34Z","remitToParty":{"partyId":"ABCDE"},"invoiceTotal":{"currencyCode":"USD","amount":"112.05"},"shipFromParty":{"partyId":"TES1"},"billToParty":{"partyId":"TES1"}}]}
```

Then on v7 I am getting the following exception:

```
Saloon\Exceptions\Request\ClientException: Bad Request (400) Response: {
  "errors": [
    {
      "code": "InvalidInput",
      "message": "Could not match input arguments",
      "details": ""
    }
  ]
}
```

and then, all works fine, when I update the datetime format to provide the seconds fraction as in this PR.