### PR TITLE
Add definitions for SNS reports currently missing from reports.json

### DIFF
--- a/resources/reports.json
+++ b/resources/reports.json
@@ -664,6 +664,20 @@
     "schedulable": false,
     "quoteEnclosure": false
   },
+  "GET_FBA_SNS_FORECAST_DATA": {
+    "contentType": "text/tab-separated-values",
+    "restricted": false,
+    "requestable": true,
+    "schedulable": false,
+    "quoteEnclosure": false
+  },
+  "GET_FBA_SNS_PERFORMANCE_DATA": {
+    "contentType": "text/tab-separated-values",
+    "restricted": false,
+    "requestable": true,
+    "schedulable": false,
+    "quoteEnclosure": false
+  },
   "GET_FBA_UNO_INVENTORY_DATA": {
     "contentType": "text/tab-separated-values",
     "restricted": false,


### PR DESCRIPTION
There are 2 SNS (Subscribe aNd Save) reports missing from reports.json... now they are not missing any more!