### PR TITLE
Fix: details should be represented asa string boolean

### DIFF
--- a/src/Seller/FBAInventoryV1/Requests/GetInventorySummaries.php
+++ b/src/Seller/FBAInventoryV1/Requests/GetInventorySummaries.php
@@ -43,7 +43,7 @@ class GetInventorySummaries extends Request
             'granularityType' => $this->granularityType,
             'granularityId' => $this->granularityId,
             'marketplaceIds' => $this->marketplaceIds,
-            'details' => $this->details,
+            'details' => json_encode($this->details),
             'startDateTime' => $this->startDateTime?->format(\DateTime::RFC3339),
             'sellerSkus' => $this->sellerSkus,
             'sellerSku' => $this->sellerSku,


### PR DESCRIPTION
This PR addresses the issue where the `details` parameter is not properly encoded as a boolean string ("false" or "true"), as per the Amazon documentation.

**Related Issue:** https://github.com/jlevers/selling-partner-api/issues/770
**Related Amazon Doc:** https://developer-docs.amazon.com/sp-api/docs/fbainventory-api-v1-reference
### Summary of Changes:
- Fixed the `details` parameter in the `defaultQuery` method to ensure it is JSON-encoded as a boolean string.

### Notes:
- I encountered this issue in version 6.0.5 and cannot currently upgrade to 6.0.6. If possible, it would be helpful to consider this


