### PR TITLE
Add support for new Amazon SP-API reports (Search Query Performance & Search Catalog Performance Analytics)

### DIFF
--- a/resources/reports.json
+++ b/resources/reports.json
@@ -1,4 +1,18 @@
 {
+  "GET_BRAND_ANALYTICS_SEARCH_CATALOG_PERFORMANCE_REPORT": {
+    "contentType": "application/json",
+    "restricted": false,
+    "requestable": true,
+    "schedulable": false,
+    "quoteEnclosure": false
+  },
+  "GET_BRAND_ANALYTICS_SEARCH_QUERY_PERFORMANCE_REPORT": {
+    "contentType": "application/json",
+    "restricted": false,
+    "requestable": true,
+    "schedulable": false,
+    "quoteEnclosure": false
+  },
   "GET_BRAND_ANALYTICS_MARKET_BASKET_REPORT": {
     "contentType": "application/json",
     "restricted": false,


### PR DESCRIPTION
## Summary
This PR adds support for two new Amazon SP-API report types:  
- **Search Query Performance Report** (`GET_BRAND_ANALYTICS_SEARCH_QUERY_PERFORMANCE_REPORT`)  
- **Search Catalog Performance Analytics Report** (`GET_BRAND_ANALYTICS_SEARCH_CATALOG_PERFORMANCE_REPORT`)  

## Changes
- Added the new report types to the configuration with `contentType: application/json`
- Set both reports as `requestable`
- Marked them as `not restricted`, `not schedulable`, and `without quote enclosure`

## Reference
- [Amazon SP-API Changelog](https://developer-docs.amazon.com/sp-api/changelog/update-added-new-search-query-performance-and-search-catalog-performance-analytics-report-types)
