### PR TITLE
Fix phpspreadsheet version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.0|^7.0",
-        "phpoffice/phpspreadsheet": "1.25.2"
+        "phpoffice/phpspreadsheet": "^1.25.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0 || ^9.0",


### PR DESCRIPTION
phpoffice/phpspreadsheet is locked in composer.json to version 1.25.2. The fix allows a newer version (this was possible in the previous release).