### PR TITLE
Add missing BuyerEmail to OrderBuyerInfo DTO

### DIFF
--- a/resources/metadata/modifications.json
+++ b/resources/metadata/modifications.json
@@ -126,6 +126,16 @@
                     "description": "The anonymized email address of the buyer."
                 }
             }
+        },
+        {
+            "action": "merge",
+            "path": "components.schemas.OrderBuyerInfo.properties",
+            "value": {
+                "BuyerEmail": {
+                    "type": "string",
+                    "description": "The anonymized email address of the buyer."
+                }
+            }
         }
       ]
     },

--- a/resources/models/seller/orders/v0.json
+++ b/resources/models/seller/orders/v0.json
@@ -4258,6 +4258,10 @@
                     "PurchaseOrderNumber": {
                         "type": "string",
                         "description": "The purchase order (PO) number entered by the buyer at checkout. Only returned for orders where the buyer entered a PO number at checkout."
+                    },
+                    "BuyerEmail": {
+                        "type": "string",
+                        "description": "The anonymized email address of the buyer."
                     }
                 },
                 "description": "Buyer information for an order."

--- a/src/Seller/OrdersV0/Dto/OrderBuyerInfo.php
+++ b/src/Seller/OrdersV0/Dto/OrderBuyerInfo.php
@@ -20,6 +20,7 @@ final class OrderBuyerInfo extends Dto
         'buyerCounty' => 'BuyerCounty',
         'buyerTaxInfo' => 'BuyerTaxInfo',
         'purchaseOrderNumber' => 'PurchaseOrderNumber',
+        'buyerEmail' => 'BuyerEmail',
     ];
 
     /**
@@ -30,6 +31,7 @@ final class OrderBuyerInfo extends Dto
      * **Note**: This attribute is only available in the Brazil marketplace.
      * @param  ?BuyerTaxInfo  $buyerTaxInfo  Tax information about the buyer.
      * @param  ?string  $purchaseOrderNumber  The purchase order (PO) number entered by the buyer at checkout. Only returned for orders where the buyer entered a PO number at checkout.
+     * @param  ?string  $buyerEmail  The anonymized email address of the buyer.
      */
     public function __construct(
         public string $amazonOrderId,
@@ -37,5 +39,6 @@ final class OrderBuyerInfo extends Dto
         public ?string $buyerCounty = null,
         public ?BuyerTaxInfo $buyerTaxInfo = null,
         public ?string $purchaseOrderNumber = null,
+        public ?string $buyerEmail = null,
     ) {}
 }


### PR DESCRIPTION
Fixes #901.

PR #896 reintroduced `BuyerEmail` in `BuyerInfo` and `OrdersList` via `resources/metadata/modifications.json`, but missed `OrderBuyerInfo`, the schema returned by the `getOrderBuyerInfo` endpoint at `/orders/v0/orders/{orderId}/buyerInfo`. That endpoint has historically returned `BuyerEmail` (see amzn/selling-partner-api-models#896 and follow-ups).

This applies the same merge pattern used by #896 for the other two schemas, regenerates `resources/models/seller/orders/v0.json`, and updates the autogenerated `OrderBuyerInfo` DTO.

### Changes

- Add a third merge block to `modifications.json` for `components.schemas.OrderBuyerInfo.properties`, mirroring the existing entries for `BuyerInfo` and `OrdersList`
- Regenerate `resources/models/seller/orders/v0.json` with the new property
- Update the autogenerated `OrderBuyerInfo` DTO. `buyerEmail` is added as the last optional constructor parameter, matching the position of `buyerEmail` in `BuyerInfo`

### Note on regeneration

Running `php bin/console schema:refactor --category seller --schema orders` followed by `schema:generate` locally produces ~149 file changes (+3224 / -2933) due to accumulated generator and dependency drift since the last full regen, likely from the Saloon v4 upgrade in #899 plus other generator updates. The bulk of that diff is in core files like `src/BaseResource.php`, `src/Dto.php`, and `src/Traits/*`, unrelated to `OrderBuyerInfo`.

To keep this PR reviewable, I scoped it to only the three files directly relevant to fixing #901 and applied the equivalent diff to `v0.json` and the generated DTO by hand. The output matches the pattern from #896. A separate housekeeping PR for the generator drift would probably be worthwhile, let me know if you'd like me to open one.

No tests were modified because there is no existing coverage for this DTO.