### PR TITLE
Exclude dev files from package archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.gitattributes export-ignore
+/.github export-ignore
+/.gitignore export-ignore
+/CONTRIBUTING.md export-ignore
+/FUNDING.yml export-ignore
+/bin export-ignore
+/phpunit.dist.xml export-ignore
+/resources export-ignore
+/tests export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,12 @@
 /.gitattributes export-ignore
-/.github export-ignore
+/.github/** export-ignore
 /.gitignore export-ignore
 /CONTRIBUTING.md export-ignore
 /FUNDING.yml export-ignore
-/bin export-ignore
+/bin/** export-ignore
 /phpunit.dist.xml export-ignore
-/resources export-ignore
-/tests export-ignore
+/resources/apis.json export-ignore
+/resources/generator-config.json export-ignore
+/resources/metadata/** export-ignore
+/resources/models/** export-ignore
+/tests/** export-ignore


### PR DESCRIPTION
## Summary
- Add .gitattributes export-ignore rules for CI, tests, local config, and generator-only assets
- Exclude JSON schema resources that are not needed to run the generated SDK code

## Benefits
- Keeps Composer source installs and GitHub archives smaller
- Avoids vendoring test fixtures, CI config, and schema-generation inputs for downstream consumers
- Preserves runtime package files needed by third-party applications

## Testing
- Not run; packaging metadata only