### PR TITLE
Fix restrictedAuth() sending unfiltered dataElements, add regression test

### DIFF
--- a/src/SellingPartnerApi.php
+++ b/src/SellingPartnerApi.php
@@ -144,14 +144,16 @@ abstract class SellingPartnerApi extends Connector
             $cacheKey = "{$this->delegatee}.{$cacheKey}";
         }
 
-        // Only use data elements that are known to be valid for this particular endpoint
-        $dataElements = array_intersect($this->dataElements, $knownDataElements);
+        // Only use data elements that are known to be valid for this particular endpoint.
+        // array_values() re-indexes the result, since array_intersect() preserves the original
+        // keys, and json_encode() would otherwise serialize a non-contiguous array as a JSON
+        // object instead of an array once it reaches the request body.
+        $dataElements = array_values(array_intersect($this->dataElements, $knownDataElements));
         if ($dataElements) {
             $cacheKey .= ':'.implode(',', $dataElements);
         }
 
         // Using $this in closures doesn't work well
-        $dataElements = $this->dataElements;
         $delegatee = $this->delegatee;
         $tokensApi = $this->tokensApi;
         $authenticator = $this->getCacheableAuthenticator(

--- a/tests/AuthenticationTest.php
+++ b/tests/AuthenticationTest.php
@@ -258,6 +258,57 @@ class AuthenticationTest extends TestCase
         );
     }
 
+    public function test_restricted_data_token_only_requests_data_elements_known_to_the_endpoint(): void
+    {
+        $mockClient = new MockClient([
+            GetAccessTokenRequest::class => fn () => MockResponse::make([
+                'access_token' => 'access-token',
+                'token_type' => 'bearer',
+                'expires_in' => 3600,
+                'refresh_token' => 'refresh-token',
+            ]),
+            CreateRestrictedDataToken::class => MockResponse::make([
+                'restrictedDataToken' => 'restricted-data-token',
+                'expiresIn' => 3600,
+            ]),
+        ]);
+
+        // The connector is configured with data elements for the broadest endpoint that supports
+        // them (e.g. Orders v0 getOrder, which supports both shippingAddress and buyerInfo).
+        $connector = SellingPartnerApi::seller(
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+            refreshToken: 'refresh-token',
+            endpoint: Endpoint::NA_SANDBOX,
+            dataElements: ['shippingAddress', 'buyerInfo'],
+        );
+        $connector->withMockClient($mockClient);
+
+        // But getOrderItems only recognizes buyerInfo, so the restricted data token request for
+        // that endpoint must not include shippingAddress, or Amazon rejects it with:
+        // "Application does not have access to one or more requested data elements: [shippingAddress]"
+        $authenticator = $connector->restrictedAuth(
+            '/orders/v0/orders/{orderId}/orderItems',
+            'GET',
+            ['buyerInfo'],
+        );
+
+        $this->assertEquals('restricted-data-token', $authenticator->accessToken);
+
+        $this->assertEquals(
+            [
+                'restrictedResources' => [
+                    [
+                        'method' => 'GET',
+                        'path' => '/orders/v0/orders/{orderId}/orderItems',
+                        'dataElements' => ['buyerInfo'],
+                    ],
+                ],
+            ],
+            $mockClient->getLastPendingRequest()->body()->all()
+        );
+    }
+
     public function test_creates_new_delegated_restricted_data_token(): void
     {
         $mockClient = new MockClient([


### PR DESCRIPTION
Closes #859. Alternative to #860, with tests added as requested there.

## Bug

`restrictedAuth()` computes a correctly endpoint-filtered `$dataElements` via `array_intersect($this->dataElements, $knownDataElements)`, then immediately discards it by reassigning `$dataElements = $this->dataElements` before building the `RestrictedResource` request. Every restricted call ends up requesting the full connector-wide data element list regardless of the endpoint, so any endpoint whose `knownDataElements` is a strict subset (e.g. `getOrderItems`, which only supports `buyerInfo`) gets rejected by Amazon with:

```
Application does not have access to one or more requested data elements: [shippingAddress]
```

This is the same defect reported in #859 and fixed in #860 (credit to @lc-excell for the original diagnosis and fix) — I hit it independently while upgrading this dependency downstream and wanted to contribute the tests that were being asked for on that PR, since `maintainer_can_modify` is off there and I couldn't push to it directly.

## A second bug, found while writing the test

Simply removing the reassignment line isn't quite enough: `array_intersect()` preserves the original array keys from `$this->dataElements`, and this library's DTO serializer (`HasArrayableAttributes::valueToArray()`) only reindexes typed object arrays — plain scalar arrays (like `dataElements: string[]`) pass through unchanged. So whenever the filtered result skips an earlier index (e.g. connector configured with `['shippingAddress', 'buyerInfo']`, filtered down to just `['buyerInfo']` at index `1`), `json_encode()` would serialize it as a JSON *object* (`{"1":"buyerInfo"}`) instead of a JSON *array* (`["buyerInfo"]`) once it reached the request body — which the API would also reject.

I verified this is a real, independent issue: the fix in #860 alone still fails the new test in this PR; wrapping the intersect in `array_values()` fixes it.

## Changes

- `src/SellingPartnerApi.php`: removes the overwrite, and wraps the intersect in `array_values()`.
- `tests/AuthenticationTest.php`: adds `test_restricted_data_token_only_requests_data_elements_known_to_the_endpoint`, which configures the connector with the broader data element set (as `getOrder` supports) and calls `restrictedAuth()` with the narrower set `getOrderItems` knows about, asserting only the narrower, correctly-indexed set reaches the request body.

Full suite (35 tests) passes locally.

Happy to close this in favor of #860 if you'd rather just add these tests there once maintainer edits are enabled — whatever's easiest.