### PR TITLE
Don't exclude resources/generator-config.json from package archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,6 @@
 /bin/** export-ignore
 /phpunit.dist.xml export-ignore
 /resources/apis.json export-ignore
-/resources/generator-config.json export-ignore
 /resources/metadata/** export-ignore
 /resources/models/** export-ignore
 /tests/** export-ignore


### PR DESCRIPTION
#903 marked `resources/generator-config.json` `export-ignore` in `.gitattributes` alongside genuinely dev-only files (`tests/`, `resources/models/`, `resources/apis.json`, `resources/metadata/`). Unlike those, this file is read at runtime:

```php
// src/Generator/Package.php
public static function version(): string
{
    $config = json_decode(file_get_contents(GENERATOR_CONFIG_FILE), true);
    return $config['version'];
}
```

and `SellingPartnerApi::defaultUserAgent()` calls `Package::version()` on every single request to build the User-Agent header:

```php
$version = Package::version();
$this->userAgent = "jlevers/selling-partner-api/v$version/php";
```

Since v7.4.9, anyone installing via Composer gets a package archive missing this file, so **every SP-API request fatals**:

```
file_get_contents(.../resources/generator-config.json): Failed to open stream: No such file or directory
Thrown in .../src/Generator/Package.php on line 14
```

I checked whether the other newly-excluded resource files (`apis.json`, `metadata/**`, `models/**`) are also read outside `src/Generator/` at runtime - they aren't (only `resources/feeds.json` and `resources/reports.json` are read at runtime, via `DownloadsDocument`/`UploadsDocument`/`RestrictedReport`, and neither of those is in the `export-ignore` list), so this is the one file that needs to come back.

Verified with `git archive HEAD --format=zip` that the file is included in the resulting archive after this change.

Reports the same underlying issue as #906.