### PR TITLE
Add undocumented amazonSellerId field to Shipping v2 AmazonOrderDetails

### DIFF
--- a/resources/metadata/modifications.json
+++ b/resources/metadata/modifications.json
@@ -191,6 +191,17 @@
             "action": "replace",
             "path": "paths./shipping/v2/carrierAccounts/{carrierId}.put.operationId",
             "value": "updateLinkedCarrierAccount"
+        },
+        {
+          "comment": "Add the undocumented amazonSellerId property to AmazonOrderDetails. Amazon accepts (and, for the 3PL Buy Shipping pilot, requires) this field so that a third-party logistics provider can buy shipping for an order belonging to a different seller than the one whose credentials are being used, but it is missing from the published model.",
+          "action": "merge",
+          "path": "components.schemas.AmazonOrderDetails.properties",
+          "value": {
+            "amazonSellerId": {
+              "type": "string",
+              "description": "The seller identifier of the Amazon seller that owns the order. Only needed when buying shipping on behalf of another seller (the 3PL Buy Shipping pilot); leave it unset to buy shipping for your own orders."
+            }
+          }
         }
       ]
     },

--- a/resources/models/seller/shipping/v2.json
+++ b/resources/models/seller/shipping/v2.json
@@ -10386,6 +10386,10 @@
                     "orderId": {
                         "type": "string",
                         "description": "The Amazon order ID associated with the Amazon order fulfilled by this shipment."
+                    },
+                    "amazonSellerId": {
+                        "type": "string",
+                        "description": "The seller identifier of the Amazon seller that owns the order. Only needed when buying shipping on behalf of another seller (the 3PL Buy Shipping pilot); leave it unset to buy shipping for your own orders."
                     }
                 },
                 "description": "Amazon order information. This is required if the shipment source channel is Amazon."

--- a/src/Seller/ShippingV2/Dto/AmazonOrderDetails.php
+++ b/src/Seller/ShippingV2/Dto/AmazonOrderDetails.php
@@ -16,8 +16,10 @@ final class AmazonOrderDetails extends Dto
 {
     /**
      * @param  string  $orderId  The Amazon order ID associated with the Amazon order fulfilled by this shipment.
+     * @param  ?string  $amazonSellerId  The seller identifier of the Amazon seller that owns the order. Only needed when buying shipping on behalf of another seller (the 3PL Buy Shipping pilot); leave it unset to buy shipping for your own orders.
      */
     public function __construct(
         public string $orderId,
+        public ?string $amazonSellerId = null,
     ) {}
 }

--- a/tests/Seller/ShippingV2/Dto/AmazonOrderDetailsTest.php
+++ b/tests/Seller/ShippingV2/Dto/AmazonOrderDetailsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SellingPartnerApi\Tests\Seller\ShippingV2\Dto;
+
+use PHPUnit\Framework\TestCase;
+use SellingPartnerApi\Seller\ShippingV2\Dto\AmazonOrderDetails;
+
+class AmazonOrderDetailsTest extends TestCase
+{
+    public function test_amazon_seller_id_is_omitted_when_not_set()
+    {
+        $details = new AmazonOrderDetails(orderId: '111-8922865-1841805');
+
+        $this->assertNull($details->amazonSellerId);
+        $this->assertSame(['orderId' => '111-8922865-1841805'], $details->toArray());
+    }
+
+    public function test_amazon_seller_id_is_serialized_when_set()
+    {
+        $details = new AmazonOrderDetails(
+            orderId: '111-8922865-1841805',
+            amazonSellerId: 'A1B2C3D4E5F6G7',
+        );
+
+        $this->assertSame([
+            'orderId' => '111-8922865-1841805',
+            'amazonSellerId' => 'A1B2C3D4E5F6G7',
+        ], $details->toArray());
+    }
+
+    public function test_amazon_seller_id_is_deserialized()
+    {
+        $details = AmazonOrderDetails::deserialize([
+            'orderId' => '111-8922865-1841805',
+            'amazonSellerId' => 'A1B2C3D4E5F6G7',
+        ]);
+
+        $this->assertSame('111-8922865-1841805', $details->orderId);
+        $this->assertSame('A1B2C3D4E5F6G7', $details->amazonSellerId);
+    }
+}


### PR DESCRIPTION
### What

Adds an optional `amazonSellerId` property to the Shipping v2 `AmazonOrderDetails` DTO, via `resources/metadata/modifications.json` rather than by hand-editing generated code.

### Why

Shipping v2 accepts an `amazonSellerId` field inside `channelDetails.amazonOrderDetails`:

```json
"channelDetails": {
  "channelType": "AMAZON",
  "amazonOrderDetails": {
    "orderId": "111-8922865-1841805",
    "amazonSellerId": "<seller id that owns the order>"
  }
}
```

It lets a third-party logistics provider purchase shipping for an order belonging to a *different* Amazon seller than the Seller Central account whose credentials are being used — this is how Amazon's **3PL Buy Shipping pilot** works. The field is real and accepted by the API, but it is **not present in Amazon's published `shippingV2.json` model**, so the generated DTO gave callers no way to send it.

I re-downloaded the raw model from Amazon while preparing this to confirm the omission is upstream and not a stale snapshot in this repo: `resources/models/raw/seller/shipping/v2.json` comes back byte-identical to what's committed, and still has no `amazonSellerId`.

### How

Uses the same `merge` action already used for other fields missing from upstream models (e.g. `OrderBuyerInfo.BuyerEmail`, `AutomatedShippingSettings`), then regenerates:

```bash
php bin/console schema:refactor --category seller --schema shipping
php bin/console schema:generate --category seller --schema shipping
composer lint
```

Both the metadata entry and the regenerated `resources/models/seller/shipping/v2.json` + `src/Seller/ShippingV2/Dto/AmazonOrderDetails.php` are committed. Regeneration was verified idempotent beforehand — running the full chain on `seller/shipping` with no changes produces an empty diff, so no unrelated churn is bundled here.

### Backward compatibility

The property is nullable with a `null` default and is appended after the existing required `$orderId`, so existing positional and named constructor calls are unchanged. Since `HasArrayableAttributes::toArray()` ends in `array_filter(fn ($v) => $v !== null)`, `amazonSellerId` is omitted from the request payload entirely unless the caller sets it — no change to existing requests on the wire.

### Tests

Adds `tests/Seller/ShippingV2/Dto/AmazonOrderDetailsTest.php` covering omission when unset, serialization when set, and deserialization. `composer test` (38 tests, 85 assertions) and `composer lint` (Pint + PHPCompatibility across 2169 files) both pass.

### Note for maintainers

I have no way to exercise this against the live API from CI, so the field name and semantics come from observed 3PL Buy Shipping pilot usage rather than Amazon documentation — there is none to cite. The property `description` that becomes the DTO docblock is therefore my own wording, and I'm happy to reword it if you'd prefer something more conservative.
